### PR TITLE
fix line count error

### DIFF
--- a/lua/deltaview/diff.lua
+++ b/lua/deltaview/diff.lua
@@ -170,7 +170,7 @@ M.run_diff_against = function(filepath, ref)
 
     -- get file line count for context size
     local line_count_output = vim.fn.system({'wc', '-l', filepath})
-    local line_count = tonumber(vim.trim(line_count_output:match('^%d+'))) or 10000
+    local line_count = tonumber(vim.trim(line_count_output):match('^%d+')) or 10000
     local context = math.min(line_count + 100, 10000)
 
     local cmd


### PR DESCRIPTION
resolves https://github.com/kokusenz/deltaview.nvim/issues/4

on my machine, `wc -l` includes leading spaces, so it won't match the pattern. if i trim the output of `wc` before matching the pattern, it works as expected.