### PR TITLE
third optional parameter [path] to the :Delta command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,17 @@ Open an interactive menu to select and view diffs from all modified files.
 :DeltaMenu develop   " Show all files changed from develop branch
 ```
 
-#### `:Delta [ref] [context]`
+#### `:Delta [ref] [context] [path]`
 
 Open the inline delta diff view for the current path. Does not have two way cursor tracking like DeltaView. <CR> to jump to the cursor is on.
-This works on both files and directories, by being in a directory path using netrw or some other filetree plugin. This can be useful for if you want to diff specific directories rather than the whole git directory.
+This works on both files and directories, by being in a directory path using netrw or some other filetree plugin. This can be useful for if you want to diff specific directories rather than the whole git directory. 
+If you are unable to navigate to a directory because you use something like [oil.nvim](https://github.com/stevearc/oil.nvim), you can pass the path as an argument
 Context can be specified. This can be useful for searching your modified code (eg. looking for stray print statements).
 
 ```vim
 :Delta               " Show all files changed from HEAD, with +- 3 lines of context by default
 :Delta HEAD 0        " Show all files changed from HEAD, with no lines of context.
+:Delta HEAD 10 src/   " Show all files changed from HEAD, with 10 lines of context, for everything in src/
 ```
 
 **Note**: 
@@ -215,6 +217,7 @@ By default, the UI uses nerd font icons:
     - [fzf-lua](https://github.com/ibhagwan/fzf-lua)
     - [telescope](https://github.com/nvim-telescope/telescope.nvim)
     - [snacks](https://github.com/folke/snacks.nvim)
+- ? keybind to show a keybind menu, in deltaview and delta buffers
 - Split diffs, if there is demand. There are other plugins (and native neovim :DiffTool) that already do this, and do this well, so this is not a priority.
 - Remove the [Process Exited 0] message, if I can figure out how
 - delta blame view

--- a/doc/deltaview.txt
+++ b/doc/deltaview.txt
@@ -20,9 +20,6 @@ This plugin takes a less intrusive approach; display the delta pager output in a
 
 If you aren't looking for an inline diff view, or are just looking for a code review tool that is mature and feature rich, [codediff.nvim](https://github.com/esmuellert/codediff.nvim/blob/main/README.md) may be a better fit for you. This is a tool for those who prefer inline diff views.
 
-This code does not do anything impressive with regards to generating diffs, it simply integrates the inline diff view that delta provides into neovim.
-
-
 ==============================================================================
 SETUP/CONFIGURATION                                               *deltaview-setup*, *deltaview-configuration*
 
@@ -80,7 +77,7 @@ COMMANDS                                                  *deltaview-commands*
 :DeltaMenu [ref]        Opens the delta diff menu of the git directory. Uses the last ref that was used, or HEAD by default if ref is omitted.
 
                                                                 *:Delta*
-:Delta [ref] [context]  Open the delta diff view with configurable context for the current path. Does not have two way cursor tracking like DeltaView. <CR> to jump to the cursor is on. This works on both files and directories, by being in a directory path using netrw or some other filetree plugin. Context can be specified. This can be useful for searching your modified code (eg. looking for stray print statements). Show all files changed from HEAD, with +- 3 lines of context by default. Use `:Delta HEAD 0` to show all files changed from HEAD, with no lines of context.
+:Delta [ref] [context] [path]    Opens the delta diff view with configurable context for a path, without two way cursor tracking. Uses the last ref that was used, or HEAD by default. Uses the last specified context size, or 3 by default. Uses the current path (use netrw or some other filetree plugin to nav to it), or a specified path.
 
 ==============================================================================
 KEYBINDINGS                                            *deltaview-keybindings*


### PR DESCRIPTION
All commands now have autcomplete for its args as well. This change was driven by wanting to have this feature usable for users of file tree plugins that don't navigate to the actual path (eg. oil.nvim)