### PR TITLE
Bug: ENOENT error from file watchers due to literal shell command used as buffer name

### DIFF
--- a/lua/deltaview/diff_legacy.lua
+++ b/lua/deltaview/diff_legacy.lua
@@ -197,7 +197,7 @@ M.run_diff_against_file = function(filepath, ref)
     end
 
     -- check if buf with name already exists
-    local existing_buf = vim.fn.bufnr(cmd)
+    local existing_buf = vim.fn.bufnr('deltaview://diff/'..filepath)
     if existing_buf ~= -1 and vim.api.nvim_buf_is_valid(existing_buf) then
         vim.api.nvim_buf_delete(existing_buf, { force = true })
     end
@@ -226,7 +226,7 @@ M.run_diff_against_file = function(filepath, ref)
         M.setup_hunk_navigation(hunk_cmd, diff_buffer_funcs, cmd_ui)
         M.setup_yank_override(diff_buffer_funcs)
     end
-    M.display_delta_file(cmd, cmd_ui, on_ready_callback)
+    M.display_delta_file(cmd, cmd_ui, on_ready_callback, filepath)
 end
 
 --- Run a git diff for the specified path against a git ref
@@ -238,7 +238,7 @@ M.run_diff_against_path = function(path, ref)
     local hunk_cmd = 'git diff -U0 ' .. (ref ~= nil and ref or 'HEAD') .. ' -- ' .. vim.fn.shellescape(path)
 
     -- check if buf with name already exists
-    local existing_buf = vim.fn.bufnr(cmd)
+    local existing_buf = vim.fn.bufnr('deltaview://diff/' .. path)
     if existing_buf ~= -1 and vim.api.nvim_buf_is_valid(existing_buf) then
         vim.api.nvim_buf_delete(existing_buf, { force = true })
     end
@@ -272,14 +272,15 @@ M.run_diff_against_path = function(path, ref)
         M.setup_hunk_navigation(hunk_cmd, diff_buffer_funcs, cmd_ui)
         M.setup_yank_override(diff_buffer_funcs)
     end
-    M.display_delta_directory(cmd, cmd_ui, on_ready_callback)
+    M.display_delta_directory(cmd, cmd_ui, on_ready_callback, path)
 end
 
 --- display git diff delta output in a terminal buffer with cursor position syncing and all context for one file
 --- @param cmd string The git diff command to execute
 --- @param cmd_ui table The cmd_ui
 --- @param on_ready_callback function after the cmd_ui has initialized, run this function
-M.display_delta_file = function(cmd, cmd_ui, on_ready_callback)
+--- @param filepath string
+M.display_delta_file = function(cmd, cmd_ui, on_ready_callback, filepath)
     local delta_cmd = cmd .. ' | delta --line-numbers --paging=never | sed "1,7d"'
 
     -- get previous cursor state
@@ -366,7 +367,7 @@ M.display_delta_file = function(cmd, cmd_ui, on_ready_callback)
         end
     })
 
-    vim.api.nvim_buf_set_name(term_buf, cmd)
+    vim.api.nvim_buf_set_name(term_buf, 'deltaview://diff/' .. filepath)
 
     local return_to_cur_buffer = function()
         local success, err = pcall(function()
@@ -419,7 +420,8 @@ end
 --- @param cmd string The git diff command to execute
 --- @param cmd_ui table The cmd ui
 --- @param on_ready_callback function after the cmd_ui has initialized, run this function
-M.display_delta_directory = function(cmd, cmd_ui, on_ready_callback)
+--- @param path string
+M.display_delta_directory = function(cmd, cmd_ui, on_ready_callback, path)
     local delta_cmd = cmd .. ' | delta --line-numbers --paging=never'
     local name_only_cmd = cmd:gsub("diff", "diff --name-only", 1)
     local cur_buf = vim.api.nvim_get_current_buf()
@@ -543,7 +545,7 @@ M.display_delta_directory = function(cmd, cmd_ui, on_ready_callback)
         end
     })
 
-    vim.api.nvim_buf_set_name(term_buf, cmd)
+    vim.api.nvim_buf_set_name(term_buf, 'deltaview://diff/' .. path)
 
     local jump_to_chosen_diff = function()
         if last_valid_cursor_pos ~= nil then

--- a/lua/deltaview/view.lua
+++ b/lua/deltaview/view.lua
@@ -153,7 +153,7 @@ M.open_git_diff_buffer = function(filepath, ref, winnr)
     --- @cast delta_diff_data_set DiffData[]
 
     -- displays ref, filename
-    local diff_buffer_name = filepath .. '    '
+    local diff_buffer_name = 'deltaview://diff/' .. filepath .. '    '
         .. config.viewconfig().vs .. ' ' .. ref .. '    '
     vim.api.nvim_buf_set_name(bufnr, diff_buffer_name)
 
@@ -218,7 +218,7 @@ M.open_git_diff_buffer_for_path = function(path, ref, context, winnr, buf_name)
         .. config.viewconfig().vs .. ' ' .. ref .. '    '
         .. config.viewconfig().file .. ' ' .. #delta_diff_data_set .. '    '
 
-    vim.api.nvim_buf_set_name(bufnr, buf_name or diff_buffer_name)
+    vim.api.nvim_buf_set_name(bufnr, 'deltaview://diff/' .. (buf_name or diff_buffer_name))
 
     local no_context_delta_diff_data_set = utils.get_separated_diff_data_set_into_hunks_wo_context(delta_diff_data_set)
     -- this buffer variable allows hunk navigation later. having accurate hunk count also allows us to display it in the name
@@ -234,7 +234,7 @@ M.open_git_diff_buffer_for_path = function(path, ref, context, winnr, buf_name)
         diff_buffer_name = diff_buffer_name ..
             config.viewconfig().segment ..
             ' ' .. total_hunk_count .. '   '
-        vim.api.nvim_buf_set_name(bufnr, buf_name or diff_buffer_name)
+        vim.api.nvim_buf_set_name(bufnr, 'deltaview://diff/' .. (buf_name or diff_buffer_name))
     end
 
     return bufnr

--- a/tests/deltaview/test_view.lua
+++ b/tests/deltaview/test_view.lua
@@ -572,6 +572,7 @@ OpenGitDiffBuffer.properties.buffer_state_matches_expected = [[(function()
             if not name:find(filepath,      1, true) then return false end
             if not name:find(tostring(ref), 1, true) then return false end
             if not name:match('%d+')                 then return false end
+            if not name:find('deltaview://diff/', 1, true) then return false end
 
         elseif expected == false then
             if not ok        then return false end  -- unexpected throw is a bug
@@ -775,6 +776,7 @@ OpenGitDiffBufferForPath.properties.buffer_state_matches_expected = [[(function(
             local name = vim.api.nvim_buf_get_name(result)
             local expected_name = buf_name or (path .. '    vs ' .. ref)
             if not name:find(expected_name, 1, true) then return false end
+            if not name:find('deltaview://diff/', 1, true) then return false end
 
             -- for the untracked case: assert new_file=true was forwarded to Delta.git_diff
             if _G.fixture.captured_git_diff_opts ~= nil then


### PR DESCRIPTION
buf name now prefixes deltaview://diff/

issue: https://github.com/kokusenz/deltaview.nvim/issues/20