### PR TITLE
Bug: Handle binary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ commit - e3f5e0f42d645166e0f78efc7f84dc7bac86f01d
 - Fixed a crash when running `:Delta` with a context value larger than the file's line count.
 - Fixed an issue where delta buffer highlights could persist after navigating away using methods other than `<Esc>` or `q`. There is no longer emphasis highlights in the delta buffer
 - Fixed issue introduced in e3f5e0f42d645166e0f78efc7f84dc7bac86f01d (original 0.2.0 commit) where deltaview buffer names when opened from telescope are not correct - https://github.com/kokusenz/deltaview.nvim/pull/22
+- Fixed issue where binary files were displayed with nonzero line numbers in deltamenu - https://github.com/kokusenz/deltaview.nvim/pull/29
 
 ## History
 

--- a/lua/deltaview/utils.lua
+++ b/lua/deltaview/utils.lua
@@ -120,7 +120,14 @@ M.get_sorted_diffed_files = function(ref)
             numstat_result = vim.system({'git', 'diff', '--numstat', ref, '--', M.git_rel_to_abs(file)}):wait()
         end
         assert(numstat_result.code == 0 or numstat_result.code == 1)
-        local added, removed = string.match(numstat_result.stdout, "(%d+)%s+(%d+)%s+")
+        -- git diff --numstat outputs "-\t-\t<path>" for binary files; explicitly
+        -- treat that as 0 added / 0 removed rather than relying on tonumber(nil).
+        local added, removed
+        if numstat_result.stdout:match("^%-\t%-\t") then
+            added, removed = "0", "0"
+        else
+            added, removed = string.match(numstat_result.stdout, "(%d+)%s+(%d+)%s+")
+        end
         --- @type DiffNumstat
         local parsed_numstat = { added = added, removed = removed }
 

--- a/lua/deltaview/utils.lua
+++ b/lua/deltaview/utils.lua
@@ -111,23 +111,18 @@ M.get_sorted_diffed_files = function(ref)
 
     local files_w_stats = {}
     for file, tracked in pairs(files) do
-        --- @type DiffNumstat
-        local parsed_numstat
+        local numstat_result
 
         if tracked == false then
             -- untracked files have no git history; count all lines as added
-            local wc_result = vim.system({'wc', '-l', M.git_rel_to_abs(file)}):wait()
-            local line_count = tonumber(wc_result.stdout:match('^%s*(%d+)')) or 0
-            parsed_numstat = { added = line_count, removed = 0 }
+            numstat_result = vim.system({'git', 'diff', '--numstat', '--no-index', '--', '/dev/null', M.git_rel_to_abs(file)}):wait()
         else
-            local numstat_result = vim.system({'git', 'diff', '--numstat', ref, '--', M.git_rel_to_abs(file)}):wait()
-            if numstat_result.code ~= 0 and numstat_result.code ~= 1 then
-                print('ERROR: Failed to get lines of code for a diffed file')
-                return {}
-            end
-            local added, removed = string.match(numstat_result.stdout, "(%d+)%s+(%d+)%s+")
-            parsed_numstat = { added = added, removed = removed }
+            numstat_result = vim.system({'git', 'diff', '--numstat', ref, '--', M.git_rel_to_abs(file)}):wait()
         end
+        assert(numstat_result.code == 0 or numstat_result.code == 1)
+        local added, removed = string.match(numstat_result.stdout, "(%d+)%s+(%d+)%s+")
+        --- @type DiffNumstat
+        local parsed_numstat = { added = added, removed = removed }
 
         files_w_stats[file] = parsed_numstat
     end

--- a/tests/deltaview/test_utils.lua
+++ b/tests/deltaview/test_utils.lua
@@ -741,7 +741,9 @@ T['get_sorted_diffed_files()'] = new_set({
                         -- dirstat call
                         stdout = _G.fixture.dirstat_out or ''
                     elseif cmd[1] == 'git' and cmd[2] == 'diff' and cmd[3] == '--numstat' then
-                        local abs_path = cmd[6]
+                        -- untracked: {'git','diff','--numstat','--no-index','--','/dev/null', abs_path}  -> cmd[7]
+                        -- tracked:   {'git','diff','--numstat', ref,         '--', abs_path}            -> cmd[6]
+                        local abs_path = (cmd[4] == '--no-index') and cmd[7] or cmd[6]
                         local numstat_map = _G.fixture.numstat_map or {}
                         stdout = numstat_map[abs_path] or '0\t0\t' .. abs_path .. '\n'
                     else
@@ -844,6 +846,32 @@ T['get_sorted_diffed_files()']['alphabetical sort as final tiebreaker'] = functi
     eq(#result, 2)
     eq(result[1].name, 'lua/aaa.lua')
     eq(result[2].name, 'lua/zzz.lua')
+end
+
+T['get_sorted_diffed_files()']['single untracked file returns correct added count'] = function()
+    child.lua([[
+        _G.fixture.files_map   = { ['new_file.lua'] = false }
+        _G.fixture.dirstat_out = ''
+        _G.fixture.numstat_map = { ['/repo/new_file.lua'] = '7\t0\tnew_file.lua\n' }
+    ]])
+    local result = child.lua_get([[M.get_sorted_diffed_files('HEAD')]])
+    eq(#result, 1)
+    eq(result[1].name,    'new_file.lua')
+    eq(result[1].added,   7)
+    eq(result[1].removed, 0)
+end
+
+T['get_sorted_diffed_files()']['binary untracked file shows 0 added and 0 removed'] = function()
+    child.lua([[
+        _G.fixture.files_map   = { ['image.png'] = false }
+        _G.fixture.dirstat_out = ''
+        _G.fixture.numstat_map = { ['/repo/image.png'] = '-\t-\t{/dev/null => image.png}\n' }
+    ]])
+    local result = child.lua_get([[M.get_sorted_diffed_files('HEAD')]])
+    eq(#result, 1)
+    eq(result[1].name,    'image.png')
+    eq(result[1].added,   0)
+    eq(result[1].removed, 0)
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────

--- a/tests/deltaview/test_utils.lua
+++ b/tests/deltaview/test_utils.lua
@@ -716,7 +716,6 @@ end
 -- `files_map`    table<string, boolean>   returned by M.get_diffed_and_untracked_files
 -- `dirstat_out`  string                   fake git dirstat output
 -- `numstat_map`  table<string, string>    path -> numstat line e.g. "3\t1\tpath"
--- `wc_map`       table<string, string>    path -> wc -l output e.g. "5 path"
 
 T['get_sorted_diffed_files()'] = new_set({
     hooks = {
@@ -737,7 +736,6 @@ T['get_sorted_diffed_files()'] = new_set({
                     -- Distinguish the three vim.system call sites by command shape:
                     -- 1. dirstat: {'git', 'diff', ref, '-X', '--dirstat=lines,0'}
                     -- 2. numstat: {'git', 'diff', '--numstat', ref, '--', abs_path}
-                    -- 3. wc:      {'wc', '-l', abs_path}
                     local stdout
                     if cmd[1] == 'git' and cmd[2] == 'diff' and cmd[4] == '-X' then
                         -- dirstat call
@@ -746,10 +744,6 @@ T['get_sorted_diffed_files()'] = new_set({
                         local abs_path = cmd[6]
                         local numstat_map = _G.fixture.numstat_map or {}
                         stdout = numstat_map[abs_path] or '0\t0\t' .. abs_path .. '\n'
-                    elseif cmd[1] == 'wc' then
-                        local abs_path = cmd[3]
-                        local wc_map = _G.fixture.wc_map or {}
-                        stdout = wc_map[abs_path] or '0 ' .. abs_path .. '\n'
                     else
                         stdout = ''
                     end
@@ -793,19 +787,6 @@ T['get_sorted_diffed_files()']['single tracked file returns correct name, added,
     eq(result[1].name,    'lua/foo.lua')
     eq(result[1].added,   10)
     eq(result[1].removed, 3)
-end
-
-T['get_sorted_diffed_files()']['single untracked file uses wc -l for added count'] = function()
-    child.lua([[
-        _G.fixture.files_map = { ['new.lua'] = false }
-        _G.fixture.dirstat_out = ''
-        _G.fixture.wc_map = { ['/repo/new.lua'] = '   7 /repo/new.lua\n' }
-    ]])
-    local result = child.lua_get([[M.get_sorted_diffed_files('HEAD')]])
-    eq(#result, 1)
-    eq(result[1].name,    'new.lua')
-    eq(result[1].added,   7)
-    eq(result[1].removed, 0)
 end
 
 T['get_sorted_diffed_files()']['files sorted by directory dirstat weight descending'] = function()


### PR DESCRIPTION
The actual work was done in https://github.com/kokusenz/delta.lua/pull/3 to handle binary files.
This change is very minimal and independent of that change, just updates a utility function to use numstat instead of wc; wc provides a nonzero word count for binary files, numstat provides +0,-0 as expected. 

This change affects the given change count in deltamenu headers. Provides the option of having something discernable (I believe +0,-0 is only on binary files) in the future if I want to implement configuration to hide/remove binary files from deltamenu. Currently leaning towards not excluding binary files from deltamenu; delta.lua will display it, exactly like how delta would, and there is no performance downside to rendering 3 lines.