### PR TITLE
Feature: allow :DeltaView and :Delta from outside git repository

### DIFF
--- a/lua/deltaview/commands.lua
+++ b/lua/deltaview/commands.lua
@@ -126,7 +126,7 @@ M.Delta = function(command_argument)
         require('deltaview.view').delta_path(state.diff_target_ref, state.default_context, path)
     end)
     if not success then
-        print('ERROR: Failed to create diff view: ' .. tostring(err))
+        vim.notify('Failed to open Delta - ' .. tostring(err), vim.log.levels.ERROR)
     end
 end
 

--- a/lua/deltaview/utils.lua
+++ b/lua/deltaview/utils.lua
@@ -35,18 +35,6 @@ M.is_untracked_file = function(path, git_root)
     return is_untracked
 end
 
---- @param path string
---- @param git_root string | nil optional git root, in which case this function just stitches path to git_root
---- @return string | nil
-M.get_rel_path_from_abs = function(path, git_root)
-    if git_root ~= nil then
-        return path:sub(#git_root + 2)
-    end
-    local result = vim.system({'git', 'rev-parse', '--show-toplevel'}):wait()
-    assert(result.code == 0, 'Failed to calculate git root. ' .. result.stderr)
-    local calculated_git_root = utils.get_git_root(path)
-    return path:sub(#calculated_git_root + 2)
-end
 
 --- Get list of modified and untracked files
 --- @param ref string target ref

--- a/lua/deltaview/utils.lua
+++ b/lua/deltaview/utils.lua
@@ -1,13 +1,16 @@
 local M = {}
 
 --- Get list of untracked files
+--- @param git_root string | nil
 --- @return string[] list of untracked file paths
-M.get_untracked_files = function()
-    local result = vim.system({'git', 'ls-files', '-o', '--exclude-standard'}):wait()
-    if result.code ~= 0 and result.code ~= 1 then
-        vim.notify('Failed to get untracked files from git.', vim.log.levels.ERROR)
-        return {}
+M.get_untracked_files = function(git_root)
+    local result
+    if git_root ~= nil then
+        result = vim.system({'git', '-C', git_root, 'ls-files', '-o', '--exclude-standard'}):wait()
+    else
+        result = vim.system({'git', 'ls-files', '-o', '--exclude-standard'}):wait()
     end
+    assert(result.code == 0 or result.code == 1, 'Failed to get untracked files from git. ' .. result.stderr)
 
     local files = {}
     for match in result.stdout:gmatch('[^\n]+') do
@@ -19,10 +22,11 @@ M.get_untracked_files = function()
 end
 
 --- @param path string
+--- @param git_root string | nil optional git root to check untracked for. Absolute path.
 --- @return boolean
-M.is_untracked_file = function(path)
+M.is_untracked_file = function(path, git_root)
     local is_untracked = false
-    local untracked = M.get_untracked_files()
+    local untracked = M.get_untracked_files(git_root)
     for _, f in ipairs(untracked) do
         if M.git_rel_to_abs(f) == path then
             is_untracked = true
@@ -32,14 +36,16 @@ M.is_untracked_file = function(path)
 end
 
 --- @param path string
+--- @param git_root string | nil optional git root, in which case this function just stitches path to git_root
 --- @return string | nil
-M.get_rel_path_from_abs = function(path)
-    local result = vim.system({'git', 'rev-parse', '--show-toplevel'}):wait()
-    if result.code ~= 0 then
-        return
+M.get_rel_path_from_abs = function(path, git_root)
+    if git_root ~= nil then
+        return path:sub(#git_root + 2)
     end
-    local git_root = vim.trim(result.stdout)
-    return path:sub(#git_root + 2)
+    local result = vim.system({'git', 'rev-parse', '--show-toplevel'}):wait()
+    assert(result.code == 0, 'Failed to calculate git root. ' .. result.stderr)
+    local calculated_git_root = utils.get_git_root(path)
+    return path:sub(#calculated_git_root + 2)
 end
 
 --- Get list of modified and untracked files
@@ -495,21 +501,15 @@ M.get_adjacent_files_legacy = function(diffed_files)
     }
 end
 
---- Resolve a git ref for use in `git show <ref>:<path>`.
---- `git show` does not support three-dot symmetric-difference notation
---- (e.g. `main...HEAD`), while `git diff` does. When a three-dot ref is
---- @param ref string  The ref string to resolve (e.g. `'main...HEAD'`).
---- @return string ref (a plain SHA for three-dot inputs, or the original string for all other inputs).
-M.resolve_ref_for_show = function(ref)
-    local a, b = ref:match('^(.-)%.%.%.(.+)$')
-    if not a then
-        return ref  -- not a three-dot ref; return as-is
-    end
-    local result = vim.system({ 'git', 'merge-base', a, b }):wait()
-    if result.code ~= 0 then
-        return ref  -- can't resolve; return original so the caller gets a clear git error
-    end
-    return vim.trim(result.stdout)
+--- gets the git root of the path; if there is no git root, then throws an error
+--- @param path string works on filepath or directory path
+--- @return string git_root
+M.get_git_root = function(path)
+    -- returns the directory containing the path
+    local file_dir = vim.fn.isdirectory(path) == 1 and path or vim.fn.fnamemodify(path, ':h')
+    local rev_parse_result = vim.system({ 'git', '-C', file_dir, 'rev-parse', '--show-toplevel' }):wait()
+    assert(rev_parse_result.code == 0, 'Not in a git repository. - ' .. rev_parse_result.stderr)
+    return vim.trim(rev_parse_result.stdout)
 end
 
 return M

--- a/lua/deltaview/utils.lua
+++ b/lua/deltaview/utils.lua
@@ -22,13 +22,13 @@ M.get_untracked_files = function(git_root)
 end
 
 --- @param path string
---- @param git_root string | nil optional git root to check untracked for. Absolute path.
+--- @param git_root string git root to check untracked for. Absolute path.
 --- @return boolean
 M.is_untracked_file = function(path, git_root)
     local is_untracked = false
     local untracked = M.get_untracked_files(git_root)
     for _, f in ipairs(untracked) do
-        if M.git_rel_to_abs(f) == path then
+        if (vim.trim(git_root) .. '/' .. f) == path then
             is_untracked = true
         end
     end
@@ -496,7 +496,7 @@ M.get_git_root = function(path)
     -- returns the directory containing the path
     local file_dir = vim.fn.isdirectory(path) == 1 and path or vim.fn.fnamemodify(path, ':h')
     local rev_parse_result = vim.system({ 'git', '-C', file_dir, 'rev-parse', '--show-toplevel' }):wait()
-    assert(rev_parse_result.code == 0, 'Not in a git repository. - ' .. rev_parse_result.stderr)
+    assert(rev_parse_result.code == 0, 'An error occurred while running git rev-parse - ' .. rev_parse_result.stderr)
     return vim.trim(rev_parse_result.stdout)
 end
 

--- a/lua/deltaview/view.lua
+++ b/lua/deltaview/view.lua
@@ -18,7 +18,8 @@ M.deltaview_file = function(ref)
     if diff_bufnr == nil then
         return
     end
-    M.place_cursor_delta_buffer_entry(diff_bufnr, 0, cursor_placement, og_winline)
+    vim.b[diff_bufnr].git_root = vim.b[diff_bufnr].git_root or utils.get_git_root(filepath)
+    M.place_cursor_delta_buffer_entry(diff_bufnr, 0, cursor_placement, og_winline, vim.b[diff_bufnr].git_root)
     M.setup_hunk_navigation(diff_bufnr)
     local nav_back_and_place_cursor = M.get_delta_buffer_cursor_exit_strategy(diff_bufnr, 0, cur_bufnr)
     if nav_back_and_place_cursor == nil then
@@ -49,7 +50,8 @@ M.delta_path = function(ref, context, path)
     if diff_bufnr == nil then
         return
     end
-    M.place_cursor_delta_buffer_entry(diff_bufnr, 0, cursor_placement, og_winline)
+    vim.b[diff_bufnr].git_root = vim.b[diff_bufnr].git_root or utils.get_git_root(path)
+    M.place_cursor_delta_buffer_entry(diff_bufnr, 0, cursor_placement, og_winline, vim.b[diff_bufnr].git_root)
     M.setup_hunk_navigation(diff_bufnr)
     local nav_back_and_place_cursor = M.get_delta_buffer_cursor_exit_strategy(diff_bufnr, 0)
     if nav_back_and_place_cursor == nil then
@@ -71,13 +73,7 @@ end
 --- @param winnr number | nil Optional window number to open on.
 --- @return number | nil bufnr buf id of delta.lua buffer
 M.open_git_diff_buffer = function(filepath, ref, winnr)
-    local rev_parse_result = vim.system({ 'git', 'rev-parse', '--show-toplevel' }):wait()
-    if rev_parse_result.code ~= 0 and rev_parse_result.code ~= 1 then
-        vim.notify('Not in a git repository. Cannot open git diff delta.lua buffer.', vim.log.levels.WARN)
-        return
-    end
-    local git_root = vim.trim(rev_parse_result.stdout)
-
+    local git_root = utils.get_git_root(filepath)
     assert(filepath ~= nil)
     if vim.fn.filereadable(filepath) == 0 then
         vim.notify('Not on a real file. Cannot open git diff delta.lua buffer.', vim.log.levels.WARN)
@@ -85,11 +81,11 @@ M.open_git_diff_buffer = function(filepath, ref, winnr)
     end
     assert(ref ~= nil)
 
-    local is_untracked = utils.is_untracked_file(filepath)
+    local is_untracked = utils.is_untracked_file(filepath, git_root)
     local git_data
 
     if is_untracked ~= true then
-        local diff_result = vim.system({ 'git', 'diff', '-U0', ref, '--', filepath }):wait()
+        local diff_result = vim.system({ 'git', '-C', git_root, 'diff', '-U0', ref, '--', filepath }):wait()
         if diff_result.code ~= 0 and diff_result.code ~= 1 then
             vim.notify('Failed to run git diff - ' .. diff_result.stderr, vim.log.levels.ERROR)
             return
@@ -103,11 +99,7 @@ M.open_git_diff_buffer = function(filepath, ref, winnr)
 
         git_data = Delta.parse.get_diff_data_git(diffstring)
     else
-        local new_path = utils.get_rel_path_from_abs(filepath)
-        if new_path == nil then
-            vim.notify('Not in a git repository. Cannot open git diff delta.lua buffer.', vim.log.levels.WARN)
-            return
-        end
+        local new_path = filepath:sub(#git_root + 2)
         git_data = {{
             new_path = new_path,
             old_path = nil,
@@ -121,12 +113,11 @@ M.open_git_diff_buffer = function(filepath, ref, winnr)
     local s1 = ''
 
     if git_data[1].old_path then
-        local show_ref = utils.resolve_ref_for_show(ref)
         local show_result
-        if git_data[1].old_path then
-            show_result = vim.system({ 'git', 'show', show_ref .. ':' .. git_data[1].old_path }):wait()
+        if git_data[1].new_file ~= true and git_data[1].old_blob_hash then
+            show_result = vim.system({ 'git', '-C', git_root, 'cat-file', 'blob', git_data[1].old_blob_hash }):wait()
             if show_result.code ~= 0 and show_result.code ~= 1 then
-                vim.notify('Failed to run git show - ' .. show_result.stderr, vim.log.levels.ERROR)
+                vim.notify('Failed to run git cat-file - ' .. show_result.stderr, vim.log.levels.ERROR)
                 return
             end
             s1 = show_result.stdout or ''
@@ -191,15 +182,11 @@ end
 --- @param buf_name string | nil Optional name to assign to the buffer
 --- @return number | nil bufnr buf id of delta.lua buffer
 M.open_git_diff_buffer_for_path = function(path, ref, context, winnr, buf_name)
-    local rev_parse_result = vim.system({ 'git', 'rev-parse', '--show-toplevel' }):wait()
-    if rev_parse_result.code ~= 0 and rev_parse_result.code ~= 1 then
-        vim.notify('Not in a git repository. Cannot open git diff delta.lua buffer.', vim.log.levels.WARN)
-        return
-    end
-
     assert(path ~= nil)
     assert(ref ~= nil)
-    local is_untracked = utils.is_untracked_file(path)
+    assert(context ~= nil)
+    local git_root = utils.get_git_root(path)
+    local is_untracked = utils.is_untracked_file(path, git_root)
 
     --- @type DeltaOpts
     local opts = { context = context, new_file = is_untracked }
@@ -267,17 +254,16 @@ end
 --- @param winnr number win id of delta.lua window id
 --- @param cursor_placement CursorPlacement if filepath is not specified, they will try to place the cursor on the first file of the diff. If the delta.lua buffer does not have filepath, but you know the file your cursor was on matches with the delta.lua file, use filepath = nil.
 --- @param og_winline number winline of the cursor in the source buffer, used to preserve relative screen position in the diff buffer
-M.place_cursor_delta_buffer_entry = function(bufnr, winnr, cursor_placement, og_winline)
+--- @param git_root string
+M.place_cursor_delta_buffer_entry = function(bufnr, winnr, cursor_placement, og_winline, git_root)
+    assert(bufnr ~= nil)
+    assert(winnr ~= nil)
+    assert(cursor_placement ~= nil)
+    assert(og_winline ~= nil)
+    assert(git_root ~= nil)
     local delta_diff_data_set = vim.b[bufnr].delta_diff_data_set
     assert(delta_diff_data_set ~= nil)
     --- @cast delta_diff_data_set DiffData[]
-
-    local rev_parse_result = vim.system({ 'git', 'rev-parse', '--show-toplevel' }):wait()
-    if rev_parse_result.code ~= 0 and rev_parse_result.code ~= 1 then
-        vim.notify('Not in a git repository. Cannot open git diff delta.lua buffer.', vim.log.levels.WARN)
-        return
-    end
-    local git_root = vim.trim(rev_parse_result.stdout)
 
     for _, diff_data in ipairs(delta_diff_data_set) do
         -- when using Delta.text_diff, there is no filepath in diff_data to compare to.
@@ -405,17 +391,20 @@ M.get_delta_buffer_cursor_exit_strategy = function(bufnr, winnr, alternative_buf
             goto place_cursor
         end
 
+        -- filepath ~= nil when on path flow. Relative to git_root, as it is parsed from the git diff
         if M.cursor_placement.filepath ~= nil then
+            local git_root = vim.b[bufnr].git_root
             local success, err = pcall(function()
-                vim.cmd('e ' .. vim.fn.fnameescape(M.cursor_placement.filepath))
+                vim.cmd('e ' .. vim.fn.fnameescape(git_root .. '/' .. M.cursor_placement.filepath))
             end)
             if not success then
-                vim.notify('Failed to open file: ' .. M.cursor_placement.filepath .. ' - ' .. tostring(err),
-                    vim.log.levels.ERROR)
+                vim.notify('Failed to open file: ' .. git_root .. '/' .. M.cursor_placement.filepath ..
+                    ' - ' .. tostring(err), vim.log.levels.ERROR)
                 return false
             end
         end
 
+        vim.print(M.cursor_placement.filepath)
         ::place_cursor::
         M.set_restview(winnr, og_winline, M.cursor_placement.cursor[1], M.cursor_placement.cursor[2])
         M.cursor_placement = nil

--- a/lua/deltaview/view.lua
+++ b/lua/deltaview/view.lua
@@ -404,7 +404,6 @@ M.get_delta_buffer_cursor_exit_strategy = function(bufnr, winnr, alternative_buf
             end
         end
 
-        vim.print(M.cursor_placement.filepath)
         ::place_cursor::
         M.set_restview(winnr, og_winline, M.cursor_placement.cursor[1], M.cursor_placement.cursor[2])
         M.cursor_placement = nil

--- a/lua/deltaview/view.lua
+++ b/lua/deltaview/view.lua
@@ -73,8 +73,8 @@ end
 --- @param winnr number | nil Optional window number to open on.
 --- @return number | nil bufnr buf id of delta.lua buffer
 M.open_git_diff_buffer = function(filepath, ref, winnr)
-    local git_root = utils.get_git_root(filepath)
     assert(filepath ~= nil)
+    local git_root = utils.get_git_root(filepath)
     if vim.fn.filereadable(filepath) == 0 then
         vim.notify('Not on a real file. Cannot open git diff delta.lua buffer.', vim.log.levels.WARN)
         return

--- a/tests/deltaview/test_integrations.lua
+++ b/tests/deltaview/test_integrations.lua
@@ -244,6 +244,69 @@ T['DeltaView integration']['three-dot ref: HEAD^...HEAD opens delta buffer witho
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- `:DeltaView` integration — cwd deeper than git root
+
+-- Repo structure:
+--   <tmpdir>/          ← git root
+--   <tmpdir>/test.lua  ← tracked file with working-tree change
+--   <tmpdir>/subdir/   ← cwd is set HERE (deeper than git root)
+--
+-- This fixture exercises the path where vim.fn.getcwd() != git root but the file being
+-- diffed is still inside the repo.  git rev-parse --show-toplevel succeeds because git
+-- walks up from cwd to find the .git directory.
+local setup_tmpdir_git_repo_cwd_deeper = [[
+    local tmpdir = vim.fn.tempname()
+    vim.fn.mkdir(tmpdir, 'p')
+    vim.fn.system('git -C ' .. tmpdir .. ' init')
+    vim.fn.system('git -C ' .. tmpdir .. ' config user.email "test@test.com"')
+    vim.fn.system('git -C ' .. tmpdir .. ' config user.name "Test"')
+    local f = io.open(tmpdir .. '/test.lua', 'w')
+    f:write('local x = 1\nlocal y = 2\n')
+    f:close()
+    vim.fn.system('git -C ' .. tmpdir .. ' add test.lua')
+    vim.fn.system('git -C ' .. tmpdir .. ' commit -m "initial"')
+    local f2 = io.open(tmpdir .. '/test.lua', 'w')
+    f2:write('local x = 1\nlocal y = 99\n')
+    f2:close()
+    -- subdir is cwd — deeper than the git root
+    local subdir = tmpdir .. '/subdir'
+    vim.fn.mkdir(subdir, 'p')
+    vim.cmd('cd ' .. subdir)
+    vim.cmd('edit ' .. tmpdir .. '/test.lua')
+]]
+
+T['DeltaView integration — cwd deeper than git root'] = new_set({
+    hooks = {
+        pre_case = function()
+            child.lua(setup_tmpdir_git_repo_cwd_deeper)
+        end,
+    },
+})
+
+T['DeltaView integration — cwd deeper than git root']['happy path: creates a delta buffer for a tracked file with changes'] = function()
+    child.cmd('DeltaView HEAD')
+    local has_diff_data  = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].delta_diff_data_set ~= nil')
+    local has_parsed     = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].no_context_delta_diff_data_set ~= nil')
+    local buf_on_window  = child.lua_get('vim.api.nvim_win_get_buf(0) == vim.api.nvim_get_current_buf()')
+    local name           = child.lua_get('vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())')
+    eq(has_diff_data, true)
+    eq(has_parsed, true)
+    eq(buf_on_window, true)
+    eq(name:find('HEAD',     1, true) ~= nil, true)
+    eq(name:find('test.lua', 1, true) ~= nil, true)
+    eq(name:match('%d+')    ~= nil, true)
+end
+
+T['DeltaView integration — cwd deeper than git root']['cwd is actually deeper: cwd differs from git root'] = function()
+    -- Confirm the fixture itself has cwd != git root (guards against a bad fixture)
+    local cwd      = child.lua_get('vim.fn.getcwd()')
+    local git_root = child.lua_get([[vim.trim(vim.system({'git','rev-parse','--show-toplevel'}):wait().stdout)]])
+    eq(cwd == git_root, false)
+    -- cwd must be a subdirectory of git root
+    eq(cwd:sub(1, #git_root) == git_root, true)
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- `:DeltaMenu` integration
 
 -- creates N tracked files with working-tree changes; each file{i}.lua starts as 'local x = i'
@@ -460,6 +523,46 @@ T['Delta integration']['exit: pressing q returns to the source file buffer'] = f
     child.type_keys('q')
     local current_bufnr = child.lua_get('vim.api.nvim_get_current_buf()')
     eq(current_bufnr, original_bufnr)
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- `:Delta` integration — cwd deeper than git root
+
+-- Repo structure mirrors setup_tmpdir_git_repo_cwd_deeper: git root at tmpdir,
+-- cwd set to tmpdir/subdir.  Both the no-args form (uses current buffer path) and the
+-- explicit-path form must work correctly when cwd != git root.
+T['Delta integration — cwd deeper than git root'] = new_set({
+    hooks = {
+        pre_case = function()
+            child.lua(setup_tmpdir_git_repo_cwd_deeper)
+        end,
+    },
+})
+
+T['Delta integration — cwd deeper than git root']['happy path: Delta (no args) creates a delta buffer for current file'] = function()
+    child.cmd('Delta')
+    local has_diff_data  = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].delta_diff_data_set ~= nil')
+    local has_parsed     = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].no_context_delta_diff_data_set ~= nil')
+    local buf_on_window  = child.lua_get('vim.api.nvim_win_get_buf(0) == vim.api.nvim_get_current_buf()')
+    local name           = child.lua_get('vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())')
+    eq(has_diff_data, true)
+    eq(has_parsed, true)
+    eq(buf_on_window, true)
+    eq(name:find('HEAD',     1, true) ~= nil, true)
+    eq(name:find('test.lua', 1, true) ~= nil, true)
+end
+
+T['Delta integration — cwd deeper than git root']['happy path: explicit absolute path arg resolves against git root, not cwd'] = function()
+    -- The file lives at <git_root>/test.lua; cwd is <git_root>/subdir.
+    -- Passing the absolute path must succeed even though the file is not under cwd.
+    child.lua([[
+        local git_root = vim.trim(vim.system({'git', 'rev-parse', '--show-toplevel'}):wait().stdout)
+        vim.cmd('Delta ' .. git_root .. '/test.lua')
+    ]])
+    local has_diff_data = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].delta_diff_data_set ~= nil')
+    local name          = child.lua_get('vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())')
+    eq(has_diff_data, true)
+    eq(name:find('test.lua', 1, true) ~= nil, true)
 end
 
 return T

--- a/tests/deltaview/test_integrations.lua
+++ b/tests/deltaview/test_integrations.lua
@@ -307,6 +307,69 @@ T['DeltaView integration — cwd deeper than git root']['cwd is actually deeper:
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- `:DeltaView` integration — cwd higher than git root
+
+-- Repo structure:
+--   <tmpdir>/          ← cwd is set HERE (higher than git root)
+--   <tmpdir>/repo/     ← git root (.git lives here)
+--   <tmpdir>/repo/test.lua  ← tracked file with working-tree change
+--
+-- This fixture exercises the path where git rev-parse --show-toplevel must be run against
+-- the file's directory (not cwd), because cwd has no .git directory of its own.
+local setup_tmpdir_git_repo_cwd_higher = [[
+    local tmpdir = vim.fn.tempname()
+    vim.fn.mkdir(tmpdir, 'p')
+    local repodir = tmpdir .. '/repo'
+    vim.fn.mkdir(repodir, 'p')
+    vim.fn.system('git -C ' .. repodir .. ' init')
+    vim.fn.system('git -C ' .. repodir .. ' config user.email "test@test.com"')
+    vim.fn.system('git -C ' .. repodir .. ' config user.name "Test"')
+    local f = io.open(repodir .. '/test.lua', 'w')
+    f:write('local x = 1\nlocal y = 2\n')
+    f:close()
+    vim.fn.system('git -C ' .. repodir .. ' add test.lua')
+    vim.fn.system('git -C ' .. repodir .. ' commit -m "initial"')
+    local f2 = io.open(repodir .. '/test.lua', 'w')
+    f2:write('local x = 1\nlocal y = 99\n')
+    f2:close()
+    -- tmpdir is cwd — higher than the git root (repodir)
+    vim.cmd('cd ' .. tmpdir)
+    vim.cmd('edit ' .. repodir .. '/test.lua')
+]]
+
+T['DeltaView integration — cwd higher than git root'] = new_set({
+    hooks = {
+        pre_case = function()
+            child.lua(setup_tmpdir_git_repo_cwd_higher)
+        end,
+    },
+})
+
+T['DeltaView integration — cwd higher than git root']['happy path: creates a delta buffer for a tracked file with changes'] = function()
+    child.cmd('DeltaView HEAD')
+    local has_diff_data  = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].delta_diff_data_set ~= nil')
+    local has_parsed     = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].no_context_delta_diff_data_set ~= nil')
+    local buf_on_window  = child.lua_get('vim.api.nvim_win_get_buf(0) == vim.api.nvim_get_current_buf()')
+    local name           = child.lua_get('vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())')
+    eq(has_diff_data, true)
+    eq(has_parsed, true)
+    eq(buf_on_window, true)
+    eq(name:find('HEAD',     1, true) ~= nil, true)
+    eq(name:find('test.lua', 1, true) ~= nil, true)
+    eq(name:match('%d+')    ~= nil, true)
+end
+
+T['DeltaView integration — cwd higher than git root']['cwd is actually higher: git root is a subdirectory of cwd'] = function()
+    -- Confirm the fixture itself has cwd != git root (guards against a bad fixture).
+    -- git rev-parse is run against the file's directory so it finds the repo, not cwd.
+    local cwd      = child.lua_get('vim.fn.getcwd()')
+    local git_root = child.lua_get([[vim.trim(vim.system({'git','-C',vim.fn.expand('%:p:h'),'rev-parse','--show-toplevel'}):wait().stdout)]])
+    eq(cwd == git_root, false)
+    -- git root must be a subdirectory of cwd (cwd is the parent)
+    eq(git_root:sub(1, #cwd) == cwd, true)
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- `:DeltaMenu` integration
 
 -- creates N tracked files with working-tree changes; each file{i}.lua starts as 'local x = i'
@@ -562,6 +625,33 @@ T['Delta integration — cwd deeper than git root']['happy path: explicit absolu
     local has_diff_data = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].delta_diff_data_set ~= nil')
     local name          = child.lua_get('vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())')
     eq(has_diff_data, true)
+    eq(name:find('test.lua', 1, true) ~= nil, true)
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- `:Delta` integration — cwd higher than git root
+
+-- Repo structure mirrors setup_tmpdir_git_repo_cwd_higher: git root at tmpdir/repo,
+-- cwd set to tmpdir (the parent).  get_git_root() must derive the root from the file's
+-- directory, not from cwd, so that git commands succeed.
+T['Delta integration — cwd higher than git root'] = new_set({
+    hooks = {
+        pre_case = function()
+            child.lua(setup_tmpdir_git_repo_cwd_higher)
+        end,
+    },
+})
+
+T['Delta integration — cwd higher than git root']['happy path: Delta (no args) creates a delta buffer for current file'] = function()
+    child.cmd('Delta')
+    local has_diff_data  = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].delta_diff_data_set ~= nil')
+    local has_parsed     = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].no_context_delta_diff_data_set ~= nil')
+    local buf_on_window  = child.lua_get('vim.api.nvim_win_get_buf(0) == vim.api.nvim_get_current_buf()')
+    local name           = child.lua_get('vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())')
+    eq(has_diff_data, true)
+    eq(has_parsed, true)
+    eq(buf_on_window, true)
+    eq(name:find('HEAD',     1, true) ~= nil, true)
     eq(name:find('test.lua', 1, true) ~= nil, true)
 end
 

--- a/tests/deltaview/test_integrations.lua
+++ b/tests/deltaview/test_integrations.lua
@@ -370,6 +370,130 @@ T['DeltaView integration — cwd higher than git root']['cwd is actually higher:
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- `:DeltaView` integration — untracked file
+
+-- repo with one tracked file; an untracked file is created at the git root level.
+-- cwd == git root.
+local setup_tmpdir_untracked_file = [[
+    local tmpdir = vim.fn.tempname()
+    vim.fn.mkdir(tmpdir, 'p')
+    vim.fn.system('git -C ' .. tmpdir .. ' init')
+    vim.fn.system('git -C ' .. tmpdir .. ' config user.email "test@test.com"')
+    vim.fn.system('git -C ' .. tmpdir .. ' config user.name "Test"')
+    local f = io.open(tmpdir .. '/existing.lua', 'w')
+    f:write('local x = 1\n')
+    f:close()
+    vim.fn.system('git -C ' .. tmpdir .. ' add existing.lua')
+    vim.fn.system('git -C ' .. tmpdir .. ' commit -m "initial"')
+    -- new file that is NOT git-added (untracked)
+    local f2 = io.open(tmpdir .. '/new.lua', 'w')
+    f2:write('local y = 2\n')
+    f2:close()
+    vim.cmd('cd ' .. tmpdir)
+    vim.cmd('edit ' .. tmpdir .. '/new.lua')
+]]
+
+-- Same untracked scenario with cwd set to a subdirectory (deeper than git root).
+local setup_tmpdir_untracked_file_cwd_deeper = [[
+    local tmpdir = vim.fn.tempname()
+    vim.fn.mkdir(tmpdir, 'p')
+    vim.fn.system('git -C ' .. tmpdir .. ' init')
+    vim.fn.system('git -C ' .. tmpdir .. ' config user.email "test@test.com"')
+    vim.fn.system('git -C ' .. tmpdir .. ' config user.name "Test"')
+    local f = io.open(tmpdir .. '/existing.lua', 'w')
+    f:write('local x = 1\n')
+    f:close()
+    vim.fn.system('git -C ' .. tmpdir .. ' add existing.lua')
+    vim.fn.system('git -C ' .. tmpdir .. ' commit -m "initial"')
+    local f2 = io.open(tmpdir .. '/new.lua', 'w')
+    f2:write('local y = 2\n')
+    f2:close()
+    -- subdir is cwd — deeper than the git root
+    local subdir = tmpdir .. '/subdir'
+    vim.fn.mkdir(subdir, 'p')
+    vim.cmd('cd ' .. subdir)
+    vim.cmd('edit ' .. tmpdir .. '/new.lua')
+]]
+
+-- Same untracked scenario with cwd set to the parent of the git root (higher than git root).
+local setup_tmpdir_untracked_file_cwd_higher = [[
+    local tmpdir = vim.fn.tempname()
+    vim.fn.mkdir(tmpdir, 'p')
+    local repodir = tmpdir .. '/repo'
+    vim.fn.mkdir(repodir, 'p')
+    vim.fn.system('git -C ' .. repodir .. ' init')
+    vim.fn.system('git -C ' .. repodir .. ' config user.email "test@test.com"')
+    vim.fn.system('git -C ' .. repodir .. ' config user.name "Test"')
+    local f = io.open(repodir .. '/existing.lua', 'w')
+    f:write('local x = 1\n')
+    f:close()
+    vim.fn.system('git -C ' .. repodir .. ' add existing.lua')
+    vim.fn.system('git -C ' .. repodir .. ' commit -m "initial"')
+    local f2 = io.open(repodir .. '/new.lua', 'w')
+    f2:write('local y = 2\n')
+    f2:close()
+    -- tmpdir is cwd — higher than the git root (repodir)
+    vim.cmd('cd ' .. tmpdir)
+    vim.cmd('edit ' .. repodir .. '/new.lua')
+]]
+
+-- Exercises the is_untracked_file branch of open_git_diff_buffer across all three cwd
+-- configurations: cwd == git root, cwd inside git root (deeper), cwd outside git root (higher).
+-- In every case the command must succeed and produce a delta buffer — no ERROR notifications.
+T['DeltaView integration — untracked file'] = new_set()
+
+T['DeltaView integration — untracked file']['cwd matches git root: creates a delta buffer as a new-file diff without error'] = function()
+    child.lua(setup_tmpdir_untracked_file)
+    child.lua([[
+        _G.error_notifications = {}
+        local orig_notify = vim.notify
+        vim.notify = function(msg, level, opts)
+            if level == vim.log.levels.ERROR then table.insert(_G.error_notifications, msg) end
+            orig_notify(msg, level, opts)
+        end
+    ]])
+    child.cmd('DeltaView HEAD')
+    local errors       = child.lua_get('_G.error_notifications')
+    local has_diff_data = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].delta_diff_data_set ~= nil')
+    eq(#errors, 0)
+    eq(has_diff_data, true)
+end
+
+T['DeltaView integration — untracked file']['cwd deeper than git root: creates a delta buffer as a new-file diff without error'] = function()
+    child.lua(setup_tmpdir_untracked_file_cwd_deeper)
+    child.lua([[
+        _G.error_notifications = {}
+        local orig_notify = vim.notify
+        vim.notify = function(msg, level, opts)
+            if level == vim.log.levels.ERROR then table.insert(_G.error_notifications, msg) end
+            orig_notify(msg, level, opts)
+        end
+    ]])
+    child.cmd('DeltaView HEAD')
+    local errors        = child.lua_get('_G.error_notifications')
+    local has_diff_data = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].delta_diff_data_set ~= nil')
+    eq(#errors, 0)
+    eq(has_diff_data, true)
+end
+
+T['DeltaView integration — untracked file']['cwd higher than git root: creates a delta buffer as a new-file diff without error'] = function()
+    child.lua(setup_tmpdir_untracked_file_cwd_higher)
+    child.lua([[
+        _G.error_notifications = {}
+        local orig_notify = vim.notify
+        vim.notify = function(msg, level, opts)
+            if level == vim.log.levels.ERROR then table.insert(_G.error_notifications, msg) end
+            orig_notify(msg, level, opts)
+        end
+    ]])
+    child.cmd('DeltaView HEAD')
+    local errors        = child.lua_get('_G.error_notifications')
+    local has_diff_data = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].delta_diff_data_set ~= nil')
+    eq(#errors, 0)
+    eq(has_diff_data, true)
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- `:DeltaMenu` integration
 
 -- creates N tracked files with working-tree changes; each file{i}.lua starts as 'local x = i'
@@ -510,26 +634,6 @@ end
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- `:Delta` integration
 
--- repo with one tracked file that has no working-tree changes (for "no changes" edge case)
-local setup_tmpdir_untracked_file = [[
-    local tmpdir = vim.fn.tempname()
-    vim.fn.mkdir(tmpdir, 'p')
-    vim.fn.system('git -C ' .. tmpdir .. ' init')
-    vim.fn.system('git -C ' .. tmpdir .. ' config user.email "test@test.com"')
-    vim.fn.system('git -C ' .. tmpdir .. ' config user.name "Test"')
-    local f = io.open(tmpdir .. '/existing.lua', 'w')
-    f:write('local x = 1\n')
-    f:close()
-    vim.fn.system('git -C ' .. tmpdir .. ' add existing.lua')
-    vim.fn.system('git -C ' .. tmpdir .. ' commit -m "initial"')
-    -- new file that is NOT git-added (untracked)
-    local f2 = io.open(tmpdir .. '/new.lua', 'w')
-    f2:write('local y = 2\n')
-    f2:close()
-    vim.cmd('cd ' .. tmpdir)
-    vim.cmd('edit ' .. tmpdir .. '/new.lua')
-]]
-
 T['Delta integration'] = new_set({
     hooks = {
         pre_case = function()
@@ -653,6 +757,65 @@ T['Delta integration — cwd higher than git root']['happy path: Delta (no args)
     eq(buf_on_window, true)
     eq(name:find('HEAD',     1, true) ~= nil, true)
     eq(name:find('test.lua', 1, true) ~= nil, true)
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- `:Delta` integration — untracked file
+
+-- Exercises the is_untracked_file branch of deltaview_file across all three cwd
+-- configurations: cwd == git root, cwd inside git root (deeper), cwd outside git root (higher).
+-- In every case the command must succeed and produce a delta buffer — no ERROR notifications.
+T['Delta integration — untracked file'] = new_set()
+
+T['Delta integration — untracked file']['cwd matches git root: creates a delta buffer as a new-file diff without error'] = function()
+    child.lua(setup_tmpdir_untracked_file)
+    child.lua([[
+        _G.error_notifications = {}
+        local orig_notify = vim.notify
+        vim.notify = function(msg, level, opts)
+            if level == vim.log.levels.ERROR then table.insert(_G.error_notifications, msg) end
+            orig_notify(msg, level, opts)
+        end
+    ]])
+    child.cmd('Delta')
+    local errors        = child.lua_get('_G.error_notifications')
+    local has_diff_data = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].delta_diff_data_set ~= nil')
+    eq(#errors, 0)
+    eq(has_diff_data, true)
+end
+
+T['Delta integration — untracked file']['cwd deeper than git root: creates a delta buffer as a new-file diff without error'] = function()
+    child.lua(setup_tmpdir_untracked_file_cwd_deeper)
+    child.lua([[
+        _G.error_notifications = {}
+        local orig_notify = vim.notify
+        vim.notify = function(msg, level, opts)
+            if level == vim.log.levels.ERROR then table.insert(_G.error_notifications, msg) end
+            orig_notify(msg, level, opts)
+        end
+    ]])
+    child.cmd('Delta')
+    local errors        = child.lua_get('_G.error_notifications')
+    local has_diff_data = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].delta_diff_data_set ~= nil')
+    eq(#errors, 0)
+    eq(has_diff_data, true)
+end
+
+T['Delta integration — untracked file']['cwd higher than git root: creates a delta buffer as a new-file diff without error'] = function()
+    child.lua(setup_tmpdir_untracked_file_cwd_higher)
+    child.lua([[
+        _G.error_notifications = {}
+        local orig_notify = vim.notify
+        vim.notify = function(msg, level, opts)
+            if level == vim.log.levels.ERROR then table.insert(_G.error_notifications, msg) end
+            orig_notify(msg, level, opts)
+        end
+    ]])
+    child.cmd('Delta')
+    local errors        = child.lua_get('_G.error_notifications')
+    local has_diff_data = child.lua_get('vim.b[vim.api.nvim_get_current_buf()].delta_diff_data_set ~= nil')
+    eq(#errors, 0)
+    eq(has_diff_data, true)
 end
 
 return T

--- a/tests/deltaview/test_utils.lua
+++ b/tests/deltaview/test_utils.lua
@@ -443,19 +443,6 @@ T['get_untracked_files()']['returns empty table when git output is empty'] = fun
     eq(result, {})
 end
 
-T['get_untracked_files()']['returns empty table and notifies on git error (code ~= 0 and ~= 1)'] = function()
-    child.lua([[
-        _G.fixture.system_result = { code = 128, stdout = '', stderr = '' }
-        _G.fixture.notify_called = false
-        vim.notify = function(_msg, _level)
-            _G.fixture.notify_called = true
-        end
-    ]])
-    local result = child.lua_get([[M.get_untracked_files()]])
-    local notify_called = child.lua_get([[_G.fixture.notify_called]])
-    eq(result, {})
-    eq(notify_called, true)
-end
 
 T['get_untracked_files()']['code == 1 is not treated as a hard error (returns files)'] = function()
     -- code 1 means no matches for ls-files patterns, not a git failure
@@ -472,6 +459,35 @@ T['get_untracked_files()']['strips blank trailing lines, does not include empty 
     ]])
     local result = child.lua_get([[M.get_untracked_files()]])
     eq(result, { 'a.lua', 'b.lua' })
+end
+
+T['get_untracked_files()']['calls git with -C flag when git_root is provided'] = function()
+    child.lua([[
+        _G.fixture.captured_cmd = nil
+        vim.system = function(cmd, _opts)
+            _G.fixture.captured_cmd = cmd
+            return { wait = function() return { code = 0, stdout = '', stderr = '' } end }
+        end
+    ]])
+    child.lua([[M.get_untracked_files('/some/repo')]])
+    local cmd = child.lua_get([[_G.fixture.captured_cmd]])
+    eq(cmd[1], 'git')
+    eq(cmd[2], '-C')
+    eq(cmd[3], '/some/repo')
+end
+
+T['get_untracked_files()']['calls git without -C flag when git_root is not provided'] = function()
+    child.lua([[
+        _G.fixture.captured_cmd = nil
+        vim.system = function(cmd, _opts)
+            _G.fixture.captured_cmd = cmd
+            return { wait = function() return { code = 0, stdout = '', stderr = '' } end }
+        end
+    ]])
+    child.lua([[M.get_untracked_files()]])
+    local cmd = child.lua_get([[_G.fixture.captured_cmd]])
+    eq(cmd[1], 'git')
+    eq(cmd[2], 'ls-files')
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -533,13 +549,6 @@ T['get_diffed_files()']['code == 1 is not a hard error (returns files normally)'
     eq(result, { 'changed.lua' })
 end
 
-T['get_diffed_files()']['asserts when ref is nil'] = function()
-    local result = child.lua_get([[(function()
-        local ok = pcall(M.get_diffed_files, nil)
-        return ok
-    end)()]])
-    eq(result, false)
-end
 
 T['get_diffed_files()']['captures the ref passed to the git command'] = function()
     child.lua([[
@@ -1540,7 +1549,7 @@ IsUntrackedFile.properties.untracked_paths_return_true = [[(function()
 
     for _, input in ipairs(inputs) do
         if untracked_abs[input.path] then
-            local result = M.is_untracked_file(input.path)
+            local result = M.is_untracked_file(input.path, input.git_root)
             if result ~= true then return false end
         end
     end
@@ -1561,7 +1570,7 @@ IsUntrackedFile.properties.tracked_paths_return_false = [[(function()
 
     for _, input in ipairs(inputs) do
         if not untracked_abs[input.path] then
-            local result = M.is_untracked_file(input.path)
+            local result = M.is_untracked_file(input.path, input.git_root)
             if result ~= false then return false end
         end
     end
@@ -1572,7 +1581,7 @@ end)()]]
 IsUntrackedFile.properties.always_returns_boolean = [[(function()
     local inputs = _G.fixture.inputs
     for _, input in ipairs(inputs) do
-        local result = M.is_untracked_file(input.path)
+        local result = M.is_untracked_file(input.path, input.git_root)
         if type(result) ~= 'boolean' then return false end
     end
     return true
@@ -1583,7 +1592,7 @@ T['is_untracked_file() properties'] = new_set({
         pre_case = function()
             child.lua([[
                 -- Stub get_untracked_files so it returns the fixture's rel paths
-                M.get_untracked_files = function()
+                M.get_untracked_files = function(_git_root)
                     return _G.fixture.inputs[1] and _G.fixture.inputs[1].untracked_rel or {}
                 end
 
@@ -1597,6 +1606,47 @@ T['is_untracked_file() properties'] = new_set({
     },
 })
 
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- is_untracked_file() - example based tests
+
+T['is_untracked_file()'] = new_set({
+    hooks = {
+        pre_case = function()
+            child.lua([[
+                M.git_rel_to_abs = function(rel)
+                    return '/repo/' .. rel
+                end
+            ]])
+        end,
+    },
+})
+
+T['is_untracked_file()']['forwards git_root to get_untracked_files'] = function()
+    child.lua([[
+        _G.fixture.captured_git_root = nil
+        M.get_untracked_files = function(git_root)
+            _G.fixture.captured_git_root = git_root
+            return {}
+        end
+    ]])
+    child.lua([[M.is_untracked_file('/repo/file.lua', '/repo')]])
+    local captured = child.lua_get([[_G.fixture.captured_git_root]])
+    eq(captured, '/repo')
+end
+
+T['is_untracked_file()']['passes nil git_root to get_untracked_files when not provided'] = function()
+    child.lua([[
+        _G.fixture.captured_git_root = 'sentinel'
+        M.get_untracked_files = function(git_root)
+            _G.fixture.captured_git_root = git_root
+            return {}
+        end
+    ]])
+    child.lua([[M.is_untracked_file('/repo/file.lua')]])
+    local captured = child.lua_get([[_G.fixture.captured_git_root]])
+    eq(captured, vim.NIL)
+end
+
 for func_name, func in pairs(IsUntrackedFile.properties) do
     for _, case in ipairs(IsUntrackedFile.cases) do
         local test_name = func_name .. ': ' .. case.name
@@ -1609,135 +1659,36 @@ for func_name, func in pairs(IsUntrackedFile.properties) do
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
--- get_rel_path_from_abs() - property based tests
+-- get_git_root() - example based tests
 
-local GetRelPathFromAbs = {}
-
---- Returns a list of {abs_path, git_root} inputs covering a range of absolute paths.
---- @param case_data { git_root: string, rel_paths: string[] }
---- @return table[]
-GetRelPathFromAbs.get_inputs = function(case_data)
-    local inputs = {}
-    for _, rel in ipairs(case_data.rel_paths) do
-        table.insert(inputs, {
-            abs_path = case_data.git_root .. '/' .. rel,
-            git_root = case_data.git_root,
-            rel_path = rel,
-        })
-    end
-    return inputs
-end
-
---- @class get_rel_path_from_abs__case
---- @field name string
---- @field git_root string
---- @field rel_paths string[]
-
-GetRelPathFromAbs.cases = {
-    {
-        -- Simple flat filenames under git root.
-        name      = 'flat filenames under git root',
-        git_root  = '/repo',
-        rel_paths = { 'README.md', 'Makefile', 'init.lua' },
-    },
-    {
-        -- Deep nested paths typical of a Neovim plugin.
-        name      = 'nested plugin paths',
-        git_root  = '/home/user/myproject',
-        rel_paths = { 'lua/myproject/init.lua', 'lua/myproject/utils.lua', 'tests/test_utils.lua' },
-    },
-    {
-        -- Git root path itself contains directory separators (common in real machines).
-        name      = 'git root with deep prefix',
-        git_root  = '/home/runner/work/repo',
-        rel_paths = { 'src/main.lua', 'src/helpers/util.lua' },
-    },
-    {
-        -- Single file — boundary case.
-        name      = 'single file',
-        git_root  = '/workspace',
-        rel_paths = { 'only.lua' },
-    },
-    {
-        -- Files with dots and dashes in names.
-        name      = 'filenames with dots and dashes',
-        git_root  = '/srv/app',
-        rel_paths = { 'some-module.lua', 'config.dev.lua', 'tests/my-test.lua' },
-    },
-}
-
-GetRelPathFromAbs.properties = {}
-
--- The returned relative path re-joined with the git root must equal the original abs path.
-GetRelPathFromAbs.properties.round_trips_to_abs_path = [[(function()
-    local inputs = _G.fixture.inputs
-    for _, input in ipairs(inputs) do
-        local result = M.get_rel_path_from_abs(input.abs_path)
-        if result == nil then return false end
-        if (input.git_root .. '/' .. result) ~= input.abs_path then return false end
-    end
-    return true
-end)()]]
-
--- The result must equal the known expected relative path.
-GetRelPathFromAbs.properties.returns_expected_rel_path = [[(function()
-    local inputs = _G.fixture.inputs
-    for _, input in ipairs(inputs) do
-        local result = M.get_rel_path_from_abs(input.abs_path)
-        if result ~= input.rel_path then return false end
-    end
-    return true
-end)()]]
-
--- The result must not start with a slash (it is relative, not absolute).
-GetRelPathFromAbs.properties.result_is_relative = [[(function()
-    local inputs = _G.fixture.inputs
-    for _, input in ipairs(inputs) do
-        local result = M.get_rel_path_from_abs(input.abs_path)
-        if result == nil then return false end
-        if vim.startswith(result, '/') then return false end
-    end
-    return true
-end)()]]
-
--- The result must not contain the git root as a prefix.
-GetRelPathFromAbs.properties.result_has_no_git_root_prefix = [[(function()
-    local inputs = _G.fixture.inputs
-    for _, input in ipairs(inputs) do
-        local result = M.get_rel_path_from_abs(input.abs_path)
-        if result == nil then return false end
-        if vim.startswith(result, input.git_root) then return false end
-    end
-    return true
-end)()]]
-
-T['get_rel_path_from_abs() properties'] = new_set({
+T['get_git_root()'] = new_set({
     hooks = {
         pre_case = function()
             child.lua([[
-                -- Stub vim.system so git rev-parse returns the fixture's git root
-                vim.system = function(_cmd, _opts)
-                    return {
-                        wait = function()
-                            local git_root = _G.fixture.inputs[1] and _G.fixture.inputs[1].git_root or ''
-                            return { code = 0, stdout = git_root .. '\n', stderr = '' }
-                        end
-                    }
+                vim.fn.isdirectory = function(_) return 0 end
+                vim.fn.fnamemodify = function(path, _) return path end
+                vim.system = function(cmd, _opts)
+                    _G.fixture.captured_cmd = cmd
+                    return { wait = function() return { code = 0, stdout = '/repo\n', stderr = '' } end }
                 end
             ]])
         end,
     },
 })
 
-for func_name, func in pairs(GetRelPathFromAbs.properties) do
-    for _, case in ipairs(GetRelPathFromAbs.cases) do
-        local test_name = func_name .. ': ' .. case.name
-        T['get_rel_path_from_abs() properties'][test_name] = function()
-            child.lua([[_G.fixture.inputs = ...]], { GetRelPathFromAbs.get_inputs(case) })
-            local result = child.lua_get(func)
-            eq(result, true)
-        end
-    end
+T['get_git_root()']['calls git rev-parse --show-toplevel with -C and the file directory'] = function()
+    child.lua([[
+        _G.fixture.captured_cmd = nil
+        vim.fn.fnamemodify = function(_path, _mod) return '/repo/lua' end
+    ]])
+    local result = child.lua_get([[M.get_git_root('/repo/lua/file.lua')]])
+    local cmd = child.lua_get([[_G.fixture.captured_cmd]])
+    eq(cmd[1], 'git')
+    eq(cmd[2], '-C')
+    eq(cmd[3], '/repo/lua')
+    eq(cmd[4], 'rev-parse')
+    eq(cmd[5], '--show-toplevel')
+    eq(result, '/repo')
 end
 
 return T

--- a/tests/deltaview/test_view.lua
+++ b/tests/deltaview/test_view.lua
@@ -534,27 +534,14 @@ OpenGitDiffBuffer.open_git_diff_buffer__property_cases = {
     },
     {
         -- Untracked happy path: is_untracked_file=true skips git diff and git show entirely.
-        -- get_rel_path_from_abs provides the new_path; s1 is always '' (no prior content).
+        -- new_path is derived inline from filepath; s1 is always '' (no prior content).
         name = 'untracked happy path: git diff and git show skipped',
         setup_lua = open_git_diff_buffer_happy_mocks .. [=[
             package.loaded['deltaview.utils'].is_untracked_file = function(_) return true end
-            package.loaded['deltaview.utils'].get_rel_path_from_abs = function(_) return 'a' end
             Delta.parse.get_language_from_filename = function(_) return nil end
         ]=],
         inputs = {
             { filepath = 'a', ref = 'x', winnr = nil, expected_ok = true },
-        },
-    },
-    {
-        -- Untracked failure: get_rel_path_from_abs returns nil → early return nil.
-        name = 'untracked failure: get_rel_path_from_abs returns nil',
-        setup_lua = open_git_diff_buffer_happy_mocks .. [=[
-            package.loaded['deltaview.utils'].is_untracked_file = function(_) return true end
-            package.loaded['deltaview.utils'].get_rel_path_from_abs = function(_) return nil end
-            Delta.parse.get_language_from_filename = function(_) return nil end
-        ]=],
-        inputs = {
-            { filepath = 'a', ref = 'x', winnr = nil, expected_ok = false },
         },
     },
 }

--- a/tests/deltaview/test_view.lua
+++ b/tests/deltaview/test_view.lua
@@ -115,6 +115,7 @@ T['deltaview_file()'] = new_set({
 
                 -- stub all M.* functions called by deltaview_file
                 M.get_cursor_placement_current_buffer = function() return {} end
+                package.loaded['deltaview.utils'].get_git_root = function(_) return '/fake/repo' end
                 M.open_git_diff_buffer = function(_filepath, _ref)
                     local bufnr =  vim.api.nvim_create_buf(true, true)
                     _G.fixture.bufnr = bufnr
@@ -182,6 +183,7 @@ T['delta_path()'] = new_set({
 
                 -- stub all M.* functions called by delta_path
                 M.get_cursor_placement_current_buffer = function() return {} end
+                package.loaded['deltaview.utils'].get_git_root = function(_) return '/fake/repo' end
                 M.open_git_diff_buffer_for_path = function(_path, _ref, _context)
                     local bufnr = vim.api.nvim_create_buf(true, true)
                     _G.fixture.bufnr = bufnr
@@ -255,22 +257,18 @@ local open_git_diff_buffer_happy_mocks = [=[
         return 0
     end
 
+    package.loaded['deltaview.utils'].get_git_root = function(_) return '/repo' end
+
     vim.system = function(cmd, _opts)
         local stdout, code = '', 0
-        if cmd[2] == 'rev-parse' then
-            stdout = '/repo'
-        elseif cmd[2] == 'diff' then
-            if cmd[#cmd] == 'a' then
+        if cmd[4] == 'diff' then
+            if cmd[#cmd] == 'a' and cmd[6] ~= 'y' then
                 stdout = 'a valid non-empty diff string'
             else
                 code = 128
             end
-        elseif cmd[2] == 'show' then
-            if cmd[3] and cmd[3]:find('^x:') then
-                stdout = 'old file content'
-            else
-                code = 128
-            end
+        elseif cmd[4] == 'cat-file' then
+            code = 128
         end
         return { wait = function() return { code = code, stdout = stdout, stderr = 'err' } end }
     end
@@ -643,11 +641,7 @@ local OpenGitDiffBufferForPath = {}
 local open_git_diff_buffer_for_path_happy_mocks = [=[
     vim.notify = function() end
 
-    vim.system = function(cmd, _opts)
-        local stdout, code = '', 0
-        if cmd[2] == 'rev-parse' then stdout = '/repo' end
-        return { wait = function() return { code = code, stdout = stdout, stderr = '' } end }
-    end
+    package.loaded['deltaview.utils'].get_git_root = function(_) return '/repo' end
 
     package.loaded['deltaview.utils'].is_untracked_file = function(_)
         return false
@@ -695,19 +689,6 @@ OpenGitDiffBufferForPath.open_git_diff_buffer_for_path__property_cases = {
         setup_lua = open_git_diff_buffer_for_path_happy_mocks,
         inputs = {
             { path = 'src/', ref = 'HEAD', context = 3, winnr = nil, buf_name = 'my custom name', expected_ok = true },
-        },
-    },
-    {
-        -- git rev-parse fails; function returns nil before any Delta calls.
-        name = 'failure: not in a git repository (rev-parse code 2)',
-        setup_lua = open_git_diff_buffer_for_path_happy_mocks .. [=[
-            vim.system = function(cmd, _opts)
-                local code = (cmd[2] == 'rev-parse') and 2 or 0
-                return { wait = function() return { code = code, stdout = '', stderr = '' } end }
-            end
-        ]=],
-        inputs = {
-            { path = 'src/', ref = 'HEAD', context = 3, winnr = nil, buf_name = nil, expected_ok = false },
         },
     },
     {
@@ -1031,7 +1012,7 @@ PlaceCursorDeltaBufferEntry.place_cursor_delta_buffer_entry__property_cases = {
     -- when cursor_placement.filepath is set, only the matching diff entry should be used.
     {
         name = 'filepath specified and matches diff entry',
-        cursor_placement = { winnr = 0, cursor = { 3, 0 }, filepath = 'foo.lua' },
+        cursor_placement = { winnr = 0, cursor = { 3, 0 }, filepath = '/foo.lua' },
         buf_contents = { 'line1', 'line2', 'line3' },
         --- @type DiffData[]
         delta_diff_data_set = {
@@ -1066,7 +1047,7 @@ PlaceCursorDeltaBufferEntry.place_cursor_delta_buffer_entry__property_cases = {
     -- a line from the first file even when new_line_num happens to match.
     {
         name = 'multiple files, filepath routes to second file',
-        cursor_placement = { winnr = 0, cursor = { 2, 0 }, filepath = 'bar.lua' },
+        cursor_placement = { winnr = 0, cursor = { 2, 0 }, filepath = '/bar.lua' },
         buf_contents = { 'line1', 'line2' },
         --- @type DiffData[]
         delta_diff_data_set = {
@@ -1167,7 +1148,7 @@ PlaceCursorDeltaBufferEntry.place_cursor_delta_buffer_entry__property_cases = {
     -- filepath is set but matches no entry in the diff set; notify should fire and set_restview should not.
     {
         name = 'filepath does not match any diff entry',
-        cursor_placement = { winnr = 0, cursor = { 1, 0 }, filepath = 'baz.lua' },
+        cursor_placement = { winnr = 0, cursor = { 1, 0 }, filepath = '/baz.lua' },
         buf_contents = { 'line1' },
         --- @type DiffData[]
         delta_diff_data_set = {
@@ -1217,7 +1198,7 @@ PlaceCursorDeltaBufferEntry.properties.cursor_placed_on_matching_line = [[(funct
     if cursor_placement.filepath ~= nil then
         local filepath_in_diff = false
         for _, diff_data in ipairs(vim.b[bufnr].delta_diff_data_set) do
-            if diff_data.new_path == cursor_placement.filepath then
+            if ('/' .. (diff_data.new_path or '')) == cursor_placement.filepath then
                 filepath_in_diff = true
                 break
             end
@@ -1228,7 +1209,7 @@ PlaceCursorDeltaBufferEntry.properties.cursor_placed_on_matching_line = [[(funct
     -- assume: cursor row must match a new_line_num in the applicable diff entry
     local cursor_row_in_diff = false
     for _, diff_data in ipairs(vim.b[bufnr].delta_diff_data_set) do
-        if cursor_placement.filepath == nil or ('/' .. diff_data.new_path) == cursor_placement.filepath then
+        if cursor_placement.filepath == nil or ('/' .. (diff_data.new_path or '')) == cursor_placement.filepath then
             for _, hunk in ipairs(diff_data.hunks) do
                 for _, line in ipairs(hunk.lines) do
                     if line.new_line_num == cursor_placement.cursor[1] then
@@ -1243,7 +1224,7 @@ PlaceCursorDeltaBufferEntry.properties.cursor_placed_on_matching_line = [[(funct
     end
     if not cursor_row_in_diff then return true end
 
-    M.place_cursor_delta_buffer_entry(bufnr, cursor_placement.winnr, cursor_placement, 1)
+    M.place_cursor_delta_buffer_entry(bufnr, cursor_placement.winnr, cursor_placement, 1, '')
 
     if called_with == nil then
         return 'set_restview was not called'
@@ -1253,7 +1234,7 @@ PlaceCursorDeltaBufferEntry.properties.cursor_placed_on_matching_line = [[(funct
     local expected_row = nil
     local diff_data_set = vim.b[bufnr].delta_diff_data_set
     for _, diff_data in ipairs(diff_data_set) do
-        if cursor_placement.filepath == nil or diff_data.new_path == cursor_placement.filepath then
+        if cursor_placement.filepath == nil or ('/' .. (diff_data.new_path or '')) == cursor_placement.filepath then
             for _, hunk in ipairs(diff_data.hunks) do
                 for _, line in ipairs(hunk.lines) do
                     if line.new_line_num == cursor_placement.cursor[1] then
@@ -1291,7 +1272,7 @@ PlaceCursorDeltaBufferEntry.properties.fails_open = [[(function()
     M.set_restview = function() end
     vim.api.nvim_win_set_cursor = function() end
 
-    M.place_cursor_delta_buffer_entry(bufnr, cursor_placement.winnr, cursor_placement, 1)
+    M.place_cursor_delta_buffer_entry(bufnr, cursor_placement.winnr, cursor_placement, 1, '')
 
     if notify_called == true then
         if _G.fixture.cursor_placement.filepath == nil then
@@ -1299,7 +1280,7 @@ PlaceCursorDeltaBufferEntry.properties.fails_open = [[(function()
         end
         local found = false
         for _, diff_data in ipairs(_G.fixture.delta_diff_data_set) do
-            if diff_data.new_path == _G.fixture.cursor_placement.filepath then
+            if ('/' .. diff_data.new_path) == _G.fixture.cursor_placement.filepath then
                 found = true
             end
         end
@@ -1321,10 +1302,6 @@ for func_name, func in pairs(PlaceCursorDeltaBufferEntry.properties) do
             local bufnr = vim.api.nvim_create_buf(true, true)
             vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, ...)
             vim.api.nvim_set_current_buf(bufnr)
-            vim.system = function(cmd, _opts)
-                local code = (cmd[2] == 'rev-parse') and 0 or 2
-                return { wait = function() return { code = code, stdout = '', stderr = '' } end }
-            end
             _G.fixture.bufnr = bufnr
         ]], { case.buf_contents })
             child.lua([[_G.fixture.delta_diff_data_set = ...]], { case.delta_diff_data_set })
@@ -1353,10 +1330,6 @@ T['place_cursor_delta_buffer_entry() example']['calls win_set_cursor manually wi
         local bufnr = vim.api.nvim_create_buf(true, true)
         vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, ...)
         vim.api.nvim_set_current_buf(bufnr)
-        vim.system = function(cmd, _opts)
-            local code = (cmd[2] == 'rev-parse') and 0 or 2
-            return { wait = function() return { code = code, stdout = '', stderr = '' } end }
-        end
         _G.fixture.bufnr = bufnr
     ]], { case.buf_contents })
     child.lua([[_G.fixture.delta_diff_data_set = ...]], { case.delta_diff_data_set })
@@ -1372,7 +1345,7 @@ T['place_cursor_delta_buffer_entry() example']['calls win_set_cursor manually wi
         end
         M.set_restview = function() end
 
-        M.place_cursor_delta_buffer_entry(bufnr, cursor_placement.winnr, cursor_placement, 1)
+        M.place_cursor_delta_buffer_entry(bufnr, cursor_placement.winnr, cursor_placement, 1, '')
 
         if win_set_cursor_called_with == nil then
             return 'nvim_win_set_cursor was not called'
@@ -2039,6 +2012,7 @@ for func_name, func in pairs(GetDeltaBufferCursorExitStrategy.properties) do
             ]], { case.buf_contents })
             child.lua([[_G.fixture.delta_diff_data_set = ...]], { case.delta_diff_data_set })
             child.lua([[vim.b[_G.fixture.bufnr].delta_diff_data_set = _G.fixture.delta_diff_data_set]])
+            child.lua([[vim.b[_G.fixture.bufnr].git_root = '/repo']])
             if case.use_alternative_bufnr then
                 child.lua([[_G.fixture.alternative_bufnr = vim.api.nvim_create_buf(true, true)]])
             else


### PR DESCRIPTION
Feature request in: https://github.com/kokusenz/deltaview.nvim/issues/26
Also contains the bug fix for https://github.com/kokusenz/deltaview.nvim/issues/30. It was just convenient to do it here, sorry :grin: 

Given the buffer or path that :DeltaView or :Delta is being used on, the git root is calculated at diff time rather than using the current working directory.

:DeltaMenu remains tied to the cwd. :DeltaMenu will not be openable from outside the git repository.

