### PR TITLE
feat: add snacks picker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ This plugin's approach is to treat inline diffs as readonly, separate buffers. S
 ## Demos
 
 ### :DeltaView demo
+
 https://github.com/user-attachments/assets/6a28f113-9462-4568-93ca-6db6e7f8be97
 
 ### :Delta demo
+
 https://github.com/user-attachments/assets/9695e4ac-b858-41fd-9eb2-c082636dde2c
 
 ### :DeltaMenu demo
+
 https://github.com/user-attachments/assets/b4f7cac3-3d96-4a4b-9076-98cd8a33c7d6
 
 ## Features
@@ -36,9 +39,10 @@ https://github.com/user-attachments/assets/b4f7cac3-3d96-4a4b-9076-98cd8a33c7d6
 - Neovim >= 0.10
 - Git
 - [delta.lua](https://github.com/kokusenz/delta.lua). Install this separately into your neovim config using the plugin manager of your choice.
-- (Optional) An fzf picker of your choice. Currently supports
-    - [fzf-lua](https://github.com/ibhagwan/fzf-lua)
-    - [telescope](https://github.com/nvim-telescope/telescope.nvim)
+- (Optional) A picker of your choice. Currently supports
+  - [fzf-lua](https://github.com/ibhagwan/fzf-lua)
+  - [telescope](https://github.com/nvim-telescope/telescope.nvim)
+  - [snacks.nvim](https://github.com/folke/snacks.nvim)
 
 Note that this plugin does not use [delta](https://github.com/dandavison/delta), and it is not a dependency
 
@@ -70,7 +74,7 @@ Open an picker to preview, select, and view diffs from all modified files.
 #### `:Delta [path] [context] [ref]`
 
 Open the inline delta diff view for the current path. This view has a configurable amount of context to show alongside your diff hunks. Attempts to place the cursor on entry if there is a corresponding line in the diff. Will sync the cursor on exit, same as DeltaView.
-This works on both files and directories, by being in a directory path using netrw or some other filetree plugin. This can be useful for if you want to diff specific directories rather than the whole git directory. 
+This works on both files and directories, by being in a directory path using netrw or some other filetree plugin. This can be useful for if you want to diff specific directories rather than the whole git directory.
 If you are unable to navigate to a directory because you use something like [oil.nvim](https://github.com/stevearc/oil.nvim), you can pass the path as an argument
 Context can be specified. This can be useful for searching your modified code (eg. looking for stray print statements).
 
@@ -79,7 +83,8 @@ Context can be specified. This can be useful for searching your modified code (e
 :Delta . 10 main...HEAD     " Show all files changed from the common ancestor with the main branch, with 10 lines of context, for everything in the cwd
 ```
 
-**Note**: 
+**Note**:
+
 - All commands use the last ref used. If `:DeltaMenu main` was used, future calls to `:DeltaMenu`, `:DeltaView`, and `:Delta` will default to `main` instead of `HEAD`.
 
 ## Installation
@@ -92,7 +97,6 @@ vim.pack.add({
     'https://github.com/kokusenz/delta.lua'
 })
 ```
-
 
 Or your favorite plugin manager, such as [lazy.nvim](https://github.com/folke/lazy.nvim):
 
@@ -120,22 +124,22 @@ require('deltaview').setup({
 
 ### Default Keybindings
 
-| Key | Action |
-|-----|--------|
+| Key          | Action     |
+| ------------ | ---------- |
 | `<leader>dl` | :DeltaView |
 | `<leader>dm` | :DeltaMenu |
-| `<leader>da` | :Delta |
+| `<leader>da` | :Delta     |
 
 When viewing a diff (DeltaView or Delta):
 
-| Key | Action |
-|-----|--------|
-| `<Esc>` or `q` | Return to source file |
-| `<Tab>` | Jump to next hunk |
-| `<Shift-Tab>` | Jump to previous hunk |
-| `]f` | Open next file in menu (if opened from DeltaMenu, or in Delta with multiple files) |
-| `[f` | Open previous file in menu (if opened from DeltaMenu, or in Delta with multiple files) |
-| `d?` | Open the help legend, to view all possible keybinds |
+| Key            | Action                                                                                 |
+| -------------- | -------------------------------------------------------------------------------------- |
+| `<Esc>` or `q` | Return to source file                                                                  |
+| `<Tab>`        | Jump to next hunk                                                                      |
+| `<Shift-Tab>`  | Jump to previous hunk                                                                  |
+| `]f`           | Open next file in menu (if opened from DeltaMenu, or in Delta with multiple files)     |
+| `[f`           | Open previous file in menu (if opened from DeltaMenu, or in Delta with multiple files) |
+| `d?`           | Open the help legend, to view all possible keybinds                                    |
 
 All keybindings are configurable
 
@@ -166,7 +170,9 @@ require('deltaview').setup({
     -- If this setting is true, will show the delta style line numbers in the statuscolumn.
     line_numbers = false,
 
-    -- 'fzf-lua' | 'telescope' | nil - specify which picker to use. If nil, will go through the order and pick the first available. The order is fzf-lua -> telescope -> deltaview quickselect
+    -- 'fzf-lua' | 'telescope' | 'snacks' | nil - specify which picker to use.
+    -- If nil, will go through the order and pick the first available.
+    -- The order is fzf-lua -> telescope -> snacks -> deltaview quickselect
     fzf_picker = nil
 
     -- Custom keybindings
@@ -223,6 +229,7 @@ By default, the UI uses nerd font icons:
 ```
 
 ## Troubleshooting
+
 - :help DeltaView
 - Reach out via an issue
 - Read the changelog for changes or breaking changes
@@ -230,8 +237,7 @@ By default, the UI uses nerd font icons:
 ## Feature Roadmap
 
 - Options for using the pickers in:
-    - [mini.pick](https://github.com/nvim-mini/mini.pick)
-    - [snacks](https://github.com/folke/snacks.nvim)
+  - [mini.pick](https://github.com/nvim-mini/mini.pick)
 - Diff two blocks of text against each other; given a yanked section and a visual selected section, vim.text.diff what's in the register against what's highlighted, and display using delta.lua
 - AI Agent integration such that proposed changes are displayable with delta.lua
 - Allow bundling, such that users can install only deltaview.nvim without having to install delta.lua

--- a/lua/deltaview/config.lua
+++ b/lua/deltaview/config.lua
@@ -114,6 +114,6 @@ end
 --- @field default_context number | nil if running deltaview on a directory rather than a file, it will show a typical delta view with limited context. Defaults to 3. Set here, or pass it in as a second param to DeltaView, which will persist as the context for this session
 --- @field line_numbers boolean | nil If this setting is true, will show the delta style line numbers in the statuscolumn.
 -- TODO change quickselect to quickfix list, here and in documentation, after quickselect is changed to quickfix
---- @field fzf_picker 'fzf-lua' | 'telescope' | nil specify which picker to use. If nil, will go through the order and pick the first available. fzf-lua -> telescope -> quickselect
+--- @field fzf_picker 'fzf-lua' | 'telescope' | 'snacks' | nil specify which picker to use. If nil, will go through the order and pick the first available. fzf-lua -> telescope -> snacks -> quickselect
 
 return M

--- a/lua/deltaview/health.lua
+++ b/lua/deltaview/health.lua
@@ -44,6 +44,7 @@ M.check = function()
 
     local has_fzf_lua = pcall(require, 'fzf-lua')
     local has_telescope = pcall(require, 'telescope')
+    local has_snacks = pcall(require, 'snacks')
 
     if has_fzf_lua then
         vim.health.ok('fzf-lua available')
@@ -57,6 +58,12 @@ M.check = function()
         vim.health.warn('telescope not found (optional)')
     end
 
+    if has_snacks then
+        vim.health.ok('snacks.nvim available')
+    else
+        vim.health.warn('snacks.nvim not found (optional)')
+    end
+
     vim.health.ok('quickselect always available (built-in fallback)')
 
     -- report which picker will actually be used
@@ -66,12 +73,16 @@ M.check = function()
         active_picker = has_fzf_lua and 'fzf-lua (configured)' or 'fzf-lua configured but not found — will use auto-detect'
     elseif configured == 'telescope' then
         active_picker = has_telescope and 'telescope (configured)' or 'telescope configured but not found — will use auto-detect'
+    elseif configured == 'snacks' then
+        active_picker = has_snacks and 'snacks.nvim (configured)' or 'snacks.nvim configured but not found — will use auto-detect'
     else
-        -- auto-detect order: fzf-lua -> telescope -> quickselect
+        -- auto-detect order: fzf-lua -> telescope -> snacks -> quickselect
         if has_fzf_lua then
             active_picker = 'fzf-lua (auto)'
         elseif has_telescope then
             active_picker = 'telescope (auto)'
+        elseif has_snacks then
+            active_picker = 'snacks.nvim (auto)'
         else
             active_picker = 'quickselect (built-in)'
         end

--- a/lua/deltaview/menu.lua
+++ b/lua/deltaview/menu.lua
@@ -55,9 +55,17 @@ M.choose_deltaview_fzf_menu = function(ref, mods, changes_data)
         end
         picker.open_deltaview_telescope_menu(ref, mods, changes_data)
         return
+    elseif config.options.fzf_picker == 'snacks' then
+        local ok = pcall(require, 'snacks')
+        if not ok then
+            vim.notify('snacks.nvim not found. attempting to use the first picker available.', vim.log.levels.WARN)
+            goto default
+        end
+        picker.open_deltaview_snacks_menu(ref, mods, changes_data)
+        return
     end
     ::default::
-    -- try default order - fzf-lua -> quick_select
+    -- try default order - fzf-lua -> telescope -> snacks -> quickselect
     local fzf_lua_ok = pcall(require, 'fzf-lua')
     if fzf_lua_ok then
         picker.open_deltaview_fzf_lua_menu(ref, mods, changes_data)
@@ -67,6 +75,12 @@ M.choose_deltaview_fzf_menu = function(ref, mods, changes_data)
     local telescope_ok = pcall(require, 'telescope')
     if telescope_ok then
         picker.open_deltaview_telescope_menu(ref, mods, changes_data)
+        return
+    end
+
+    local snacks_ok = pcall(require, 'snacks')
+    if snacks_ok then
+        picker.open_deltaview_snacks_menu(ref, mods, changes_data)
         return
     end
 

--- a/lua/deltaview/picker.lua
+++ b/lua/deltaview/picker.lua
@@ -304,4 +304,88 @@ M.open_deltaview_telescope_menu = function(ref, mods, changes_data)
     }):find()
 end
 
+--- @param ref string git ref to compare against. Can be branch, commit, tag, etc.
+--- @param mods string[]
+--- @param changes_data table<string, string[]> for each file in mods, the size of the change in the file
+M.open_deltaview_snacks_menu = function(ref, mods, changes_data)
+    assert(ref ~= nil)
+    assert(mods ~= nil)
+    assert(changes_data ~= nil)
+
+    local Snacks = require('snacks')
+    local items = {}
+    for _, filepath in ipairs(mods) do
+        table.insert(items, {
+            text = filepath,
+            value = filepath,
+            file = utils.git_rel_to_abs(filepath),
+        })
+    end
+
+    Snacks.picker.pick({
+        source = 'deltaview',
+        title = 'DeltaView Menu',
+        items = items,
+        format = function(item)
+            return {
+                { item.text },
+                { '    │    ' .. tostring((changes_data[item.value] or {})[1] or '') },
+            }
+        end,
+        preview = function(ctx)
+            local filepath = utils.git_rel_to_abs(ctx.item.value)
+            if filepath == nil then
+                ctx.preview:set_lines({ 'No diff available for: ' .. ctx.item.value })
+                return true
+            end
+
+            _buf_name_seq = _buf_name_seq + 1
+            local bufnr = nil
+            local success, err = pcall(function()
+                bufnr = view.open_git_diff_buffer_for_path(filepath, ref, state.default_context, false,
+                    tostring(_buf_name_seq))
+            end)
+            if not success or bufnr == nil then
+                ctx.preview:set_lines({
+                    'No diff available for: ' .. ctx.item.value,
+                    tostring(err),
+                })
+                return true
+            end
+
+            ctx.preview:set_buf(bufnr)
+            ctx.preview:set_title(' ' .. vim.fn.fnamemodify(ctx.item.value, ':t') .. ' | '
+                .. tostring((changes_data[ctx.item.value] or {})[1] or ''))
+            ctx.preview:wo({ wrap = true })
+            return true
+        end,
+        confirm = function(picker, item)
+            picker:close()
+            if item == nil then return end
+
+            local selected = item.value
+            local selected_idx = nil
+            for idx, value in ipairs(mods) do
+                if value == selected then
+                    selected_idx = idx
+                end
+            end
+            assert(selected_idx ~= nil)
+
+            local success, err = pcall(function()
+                vim.cmd('e ' .. utils.git_rel_to_abs(vim.fn.fnameescape(selected)))
+                local bufnr = view.deltaview_file(ref)
+                if bufnr == nil then return end
+                state.diffed_files.files = mods
+                state.diffed_files.cur_idx = selected_idx
+                M.decorate_deltaview_with_next_keybinds(bufnr)
+            end)
+            if not success then
+                vim.notify('An error occured while trying to open DeltaView - ' .. tostring(err),
+                    vim.log.levels.ERROR)
+            end
+        end,
+    })
+end
+
 return M

--- a/lua/deltaview/view.lua
+++ b/lua/deltaview/view.lua
@@ -69,7 +69,7 @@ end
 --- this diff has unlimited context, and allows for one file
 --- @param filepath string The file path to diff
 --- @param ref string git ref to compare against. Can be branch, commit, tag, etc.
---- @param winnr number | nil Optional window number to open on.
+--- @param winnr number | false | nil Optional window number to open on. Pass false to create and return the buffer without displaying it.
 --- @return number | nil bufnr buf id of delta.lua buffer
 M.open_git_diff_buffer = function(filepath, ref, winnr)
     assert(filepath ~= nil)
@@ -198,12 +198,14 @@ M.open_git_diff_buffer_for_path = function(path, ref, context, winnr, buf_name)
         return
     end
 
-    local success, err = pcall(function()
-        vim.api.nvim_win_set_buf(winnr or 0, bufnr)
-    end)
-    if not success then
-        vim.notify('Failed to open buffer at window.' .. tostring(err), vim.log.levels.ERROR)
-        return
+    if winnr ~= false then
+        local success, err = pcall(function()
+            vim.api.nvim_win_set_buf(winnr or 0, bufnr)
+        end)
+        if not success then
+            vim.notify('Failed to open buffer at window.' .. tostring(err), vim.log.levels.ERROR)
+            return
+        end
     end
     delta.highlight_delta_artifacts(bufnr)
     delta.syntax_highlight_diff_set(bufnr)

--- a/tests/deltaview/test_menu.lua
+++ b/tests/deltaview/test_menu.lua
@@ -28,10 +28,10 @@ local block_modules_lua = [[
 -- setup
 
 local T = new_set({
-    hooks = {
-        pre_case = function()
-            child.restart({ '-u', 'scripts/minimal_init.lua' })
-            child.lua([[
+  hooks = {
+    pre_case = function()
+      child.restart({ '-u', 'scripts/minimal_init.lua' })
+      child.lua([[
                 package.loaded['deltaview.config'] = {
                     options = {
                         fzf_picker = nil,
@@ -44,6 +44,9 @@ local T = new_set({
                     end,
                     open_deltaview_telescope_menu = function(_ref, _mods, _changes_data)
                         _G.fixture.called = 'telescope'
+                    end,
+                    open_deltaview_snacks_menu = function(_ref, _mods, _changes_data)
+                        _G.fixture.called = 'snacks'
                     end,
                     open_deltaview_quickselect_menu = function(_ref, _mods, _changes_data)
                         _G.fixture.called = 'quickselect'
@@ -63,10 +66,10 @@ local T = new_set({
 
                 M = require('deltaview.menu')
             ]])
-            child.lua([[_G.fixture = {}]])
-        end,
-        post_once = child.stop,
-    },
+      child.lua([[_G.fixture = {}]])
+    end,
+    post_once = child.stop,
+  },
 })
 
 -- Shared test inputs
@@ -81,119 +84,159 @@ T['choose_deltaview_fzf_menu()'] = new_set()
 
 -- fzf_picker = 'fzf-lua', fzf-lua is available
 T['choose_deltaview_fzf_menu()']['calls fzf_lua picker when fzf_picker=fzf-lua and fzf-lua is available'] = function()
-    child.lua([[
+  child.lua([[
         local ref, mods, changes_data = ...
         package.loaded['deltaview.config'].options.fzf_picker = 'fzf-lua'
         package.loaded['fzf-lua'] = {}  -- simulate fzf-lua installed
         M.choose_deltaview_fzf_menu(ref, mods, changes_data)
     ]], { ref, mods, changes_data })
 
-    eq(child.lua_get('_G.fixture.called'), 'fzf_lua')
-    eq(child.lua_get('_G.fixture.notified'), vim.NIL)
+  eq(child.lua_get('_G.fixture.called'), 'fzf_lua')
+  eq(child.lua_get('_G.fixture.notified'), vim.NIL)
 end
 
--- fzf_picker = 'fzf-lua', fzf-lua NOT available → warns and falls through to default.
--- In the default path, with neither fzf-lua nor telescope, falls back to quickselect.
+-- fzf_picker = 'fzf-lua', fzf-lua NOT available -> warns and falls through to default.
+-- In the default path, with neither fzf-lua, telescope, nor snacks, falls back to quickselect.
 T['choose_deltaview_fzf_menu()']['warns and falls back to default when fzf_picker=fzf-lua but fzf-lua is missing'] = function()
-    child.lua(block_modules_lua, { 'fzf-lua', 'telescope' })
-    child.lua([[
+  child.lua(block_modules_lua, { 'fzf-lua', 'telescope', 'snacks' })
+  child.lua([[
         local ref, mods, changes_data = ...
         package.loaded['deltaview.config'].options.fzf_picker = 'fzf-lua'
         M.choose_deltaview_fzf_menu(ref, mods, changes_data)
     ]], { ref, mods, changes_data })
 
-    eq(type(child.lua_get('_G.fixture.notified')), 'string')
-    eq(child.lua_get('_G.fixture.called'), 'quickselect')
+  eq(type(child.lua_get('_G.fixture.notified')), 'string')
+  eq(child.lua_get('_G.fixture.called'), 'quickselect')
 end
 
 -- fzf_picker = 'fzf-lua', fzf-lua NOT available, but telescope IS available in default fallback
 T['choose_deltaview_fzf_menu()']['falls back to telescope in default path when fzf-lua missing but telescope available'] = function()
-    child.lua(block_modules_lua, { 'fzf-lua' })
-    child.lua([[
+  child.lua(block_modules_lua, { 'fzf-lua' })
+  child.lua([[
         local ref, mods, changes_data = ...
         package.loaded['deltaview.config'].options.fzf_picker = 'fzf-lua'
         package.loaded['telescope'] = {}  -- telescope installed
         M.choose_deltaview_fzf_menu(ref, mods, changes_data)
     ]], { ref, mods, changes_data })
 
-    eq(child.lua_get('_G.fixture.called'), 'telescope')
+  eq(child.lua_get('_G.fixture.called'), 'telescope')
 end
 
 -- fzf_picker = 'telescope', telescope is available
 T['choose_deltaview_fzf_menu()']['calls telescope picker when fzf_picker=telescope and telescope is available'] = function()
-    child.lua([[
+  child.lua([[
         local ref, mods, changes_data = ...
         package.loaded['deltaview.config'].options.fzf_picker = 'telescope'
         package.loaded['telescope'] = {}  -- simulate telescope installed
         M.choose_deltaview_fzf_menu(ref, mods, changes_data)
     ]], { ref, mods, changes_data })
 
-    eq(child.lua_get('_G.fixture.called'), 'telescope')
-    eq(child.lua_get('_G.fixture.notified'), vim.NIL)
+  eq(child.lua_get('_G.fixture.called'), 'telescope')
+  eq(child.lua_get('_G.fixture.notified'), vim.NIL)
 end
 
--- fzf_picker = 'telescope', telescope NOT available → warns and falls through to default.
--- Neither fzf-lua nor telescope available in default, so falls back to quickselect.
+-- fzf_picker = 'telescope', telescope NOT available -> warns and falls through to default.
+-- Neither fzf-lua, telescope, nor snacks available in default, so falls back to quickselect.
 T['choose_deltaview_fzf_menu()']['warns and falls back to default when fzf_picker=telescope but telescope is missing'] = function()
-    child.lua(block_modules_lua, { 'fzf-lua', 'telescope' })
-    child.lua([[
+  child.lua(block_modules_lua, { 'fzf-lua', 'telescope', 'snacks' })
+  child.lua([[
         local ref, mods, changes_data = ...
         package.loaded['deltaview.config'].options.fzf_picker = 'telescope'
         M.choose_deltaview_fzf_menu(ref, mods, changes_data)
     ]], { ref, mods, changes_data })
 
-    eq(type(child.lua_get('_G.fixture.notified')), 'string')
-    eq(child.lua_get('_G.fixture.called'), 'quickselect')
+  eq(type(child.lua_get('_G.fixture.notified')), 'string')
+  eq(child.lua_get('_G.fixture.called'), 'quickselect')
 end
 
 -- fzf_picker = 'telescope', telescope NOT available, but fzf-lua IS available in the default fallback
 T['choose_deltaview_fzf_menu()']['falls back to fzf_lua in default path when telescope missing but fzf-lua available'] = function()
-    child.lua(block_modules_lua, { 'telescope' })
-    child.lua([[
+  child.lua(block_modules_lua, { 'telescope' })
+  child.lua([[
         local ref, mods, changes_data = ...
         package.loaded['deltaview.config'].options.fzf_picker = 'telescope'
         package.loaded['fzf-lua'] = {}  -- fzf-lua installed
         M.choose_deltaview_fzf_menu(ref, mods, changes_data)
     ]], { ref, mods, changes_data })
 
-    eq(child.lua_get('_G.fixture.called'), 'fzf_lua')
+  eq(child.lua_get('_G.fixture.called'), 'fzf_lua')
 end
 
 -- default path (nil/unknown picker), fzf-lua available → uses fzf-lua
 T['choose_deltaview_fzf_menu()']['default path: uses fzf_lua when fzf-lua is available'] = function()
-    child.lua([[
+  child.lua([[
         local ref, mods, changes_data = ...
         package.loaded['deltaview.config'].options.fzf_picker = nil
         package.loaded['fzf-lua'] = {}  -- fzf-lua installed
         M.choose_deltaview_fzf_menu(ref, mods, changes_data)
     ]], { ref, mods, changes_data })
 
-    eq(child.lua_get('_G.fixture.called'), 'fzf_lua')
+  eq(child.lua_get('_G.fixture.called'), 'fzf_lua')
 end
 
 -- default path, fzf-lua NOT available, telescope available → uses telescope
 T['choose_deltaview_fzf_menu()']['default path: uses telescope when fzf-lua missing but telescope available'] = function()
-    child.lua(block_modules_lua, { 'fzf-lua' })
-    child.lua([[
+  child.lua(block_modules_lua, { 'fzf-lua' })
+  child.lua([[
         local ref, mods, changes_data = ...
         package.loaded['deltaview.config'].options.fzf_picker = nil
         package.loaded['telescope'] = {}  -- telescope installed
         M.choose_deltaview_fzf_menu(ref, mods, changes_data)
     ]], { ref, mods, changes_data })
 
-    eq(child.lua_get('_G.fixture.called'), 'telescope')
+  eq(child.lua_get('_G.fixture.called'), 'telescope')
 end
 
--- default path, neither fzf-lua nor telescope available → falls back to quickselect
+-- fzf_picker = 'snacks', snacks is available
+T['choose_deltaview_fzf_menu()']['calls snacks picker when fzf_picker=snacks and snacks is available'] = function()
+  child.lua([[
+        local ref, mods, changes_data = ...
+        package.loaded['deltaview.config'].options.fzf_picker = 'snacks'
+        package.loaded['snacks'] = {}  -- simulate snacks.nvim installed
+        M.choose_deltaview_fzf_menu(ref, mods, changes_data)
+    ]], { ref, mods, changes_data })
+
+  eq(child.lua_get('_G.fixture.called'), 'snacks')
+  eq(child.lua_get('_G.fixture.notified'), vim.NIL)
+end
+
+-- fzf_picker = 'snacks', snacks NOT available -> warns and falls through to default.
+-- Neither fzf-lua, telescope, nor snacks available in default, so falls back to quickselect.
+T['choose_deltaview_fzf_menu()']['warns and falls back to default when fzf_picker=snacks but snacks is missing'] = function()
+  child.lua(block_modules_lua, { 'fzf-lua', 'telescope', 'snacks' })
+  child.lua([[
+        local ref, mods, changes_data = ...
+        package.loaded['deltaview.config'].options.fzf_picker = 'snacks'
+        M.choose_deltaview_fzf_menu(ref, mods, changes_data)
+    ]], { ref, mods, changes_data })
+
+  eq(type(child.lua_get('_G.fixture.notified')), 'string')
+  eq(child.lua_get('_G.fixture.called'), 'quickselect')
+end
+
+-- default path, fzf-lua and telescope NOT available, snacks available -> uses snacks
+T['choose_deltaview_fzf_menu()']['default path: uses snacks when fzf-lua and telescope are missing but snacks is available'] = function()
+  child.lua(block_modules_lua, { 'fzf-lua', 'telescope' })
+  child.lua([[
+        local ref, mods, changes_data = ...
+        package.loaded['deltaview.config'].options.fzf_picker = nil
+        package.loaded['snacks'] = {}  -- snacks.nvim installed
+        M.choose_deltaview_fzf_menu(ref, mods, changes_data)
+    ]], { ref, mods, changes_data })
+
+  eq(child.lua_get('_G.fixture.called'), 'snacks')
+end
+
+-- default path, neither fzf-lua, telescope, nor snacks available -> falls back to quickselect
 T['choose_deltaview_fzf_menu()']['default path: falls back to quickselect when no picker is available'] = function()
-    child.lua(block_modules_lua, { 'fzf-lua', 'telescope' })
-    child.lua([[
+  child.lua(block_modules_lua, { 'fzf-lua', 'telescope', 'snacks' })
+  child.lua([[
         local ref, mods, changes_data = ...
         package.loaded['deltaview.config'].options.fzf_picker = nil
         M.choose_deltaview_fzf_menu(ref, mods, changes_data)
     ]], { ref, mods, changes_data })
 
-    eq(child.lua_get('_G.fixture.called'), 'quickselect')
+  eq(child.lua_get('_G.fixture.called'), 'quickselect')
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -202,19 +245,19 @@ end
 -- Helper: builds a list of sorted_file entries (the shape utils.get_sorted_diffed_files returns)
 -- and a flat list of filenames (the shape utils.get_filenames_from_sortedfiles returns).
 local function make_files(n)
-    local sorted, names = {}, {}
-    for i = 1, n do
-        local name = 'file' .. i .. '.lua'
-        table.insert(sorted, { name = name, added = i, removed = 0 })
-        table.insert(names, name)
-    end
-    return sorted, names
+  local sorted, names = {}, {}
+  for i = 1, n do
+    local name = 'file' .. i .. '.lua'
+    table.insert(sorted, { name = name, added = i, removed = 0 })
+    table.insert(names, name)
+  end
+  return sorted, names
 end
 
 T['create_diff_menu_pane()'] = new_set({
-    hooks = {
-        pre_case = function()
-            child.lua([[
+  hooks = {
+    pre_case = function()
+      child.lua([[
                 -- Happy-path defaults: we are inside a git repo, git rev-parse succeeds.
                 vim.system = function(_cmd, _opts)
                     return {
@@ -237,45 +280,45 @@ T['create_diff_menu_pane()'] = new_set({
                     _G.fixture.called = 'choose_fzf_menu'
                 end
             ]])
-        end,
-    },
+    end,
+  },
 })
 
 T['create_diff_menu_pane()']['notifies and returns when not in a git repository'] = function()
-    child.lua([[
+  child.lua([[
         vim.system = function(_cmd, _opts)
             return { wait = function() return { code = 128, stdout = '', stderr = '' } end }
         end
         M.create_diff_menu_pane('HEAD')
     ]])
 
-    eq(type(child.lua_get('_G.fixture.notified')), 'string')
-    eq(child.lua_get('_G.fixture.called'), vim.NIL)
+  eq(type(child.lua_get('_G.fixture.notified')), 'string')
+  eq(child.lua_get('_G.fixture.called'), vim.NIL)
 end
 
 T['create_diff_menu_pane()']['raises when ref is nil'] = function()
-    child.lua([[
+  child.lua([[
         local ok, _err = pcall(function() M.create_diff_menu_pane(nil) end)
         _G.fixture.assert_failed = not ok
     ]])
 
-    eq(child.lua_get('_G.fixture.assert_failed'), true)
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
 end
 
 T['create_diff_menu_pane()']['notifies and returns when there are no modified files'] = function()
-    child.lua([[
+  child.lua([[
         _G.fixture.sorted_files = {}
         _G.fixture.mods = {}
         M.create_diff_menu_pane('HEAD')
     ]])
 
-    eq(type(child.lua_get('_G.fixture.notified')), 'string')
-    eq(child.lua_get('_G.fixture.called'), vim.NIL)
+  eq(type(child.lua_get('_G.fixture.notified')), 'string')
+  eq(child.lua_get('_G.fixture.called'), vim.NIL)
 end
 
 T['create_diff_menu_pane()']['opens quickselect when mods count is below threshold'] = function()
-    local sorted, names = make_files(3)
-    child.lua([[
+  local sorted, names = make_files(3)
+  child.lua([[
         local sorted, names = ...
         _G.fixture.sorted_files = sorted
         _G.fixture.mods = names
@@ -283,12 +326,12 @@ T['create_diff_menu_pane()']['opens quickselect when mods count is below thresho
         M.create_diff_menu_pane('HEAD')
     ]], { sorted, names })
 
-    eq(child.lua_get('_G.fixture.called'), 'quickselect')
+  eq(child.lua_get('_G.fixture.called'), 'quickselect')
 end
 
 T['create_diff_menu_pane()']['opens fzf menu when mods count equals threshold'] = function()
-    local sorted, names = make_files(6)
-    child.lua([[
+  local sorted, names = make_files(6)
+  child.lua([[
         local sorted, names = ...
         _G.fixture.sorted_files = sorted
         _G.fixture.mods = names
@@ -296,12 +339,12 @@ T['create_diff_menu_pane()']['opens fzf menu when mods count equals threshold'] 
         M.create_diff_menu_pane('HEAD')
     ]], { sorted, names })
 
-    eq(child.lua_get('_G.fixture.called'), 'choose_fzf_menu')
+  eq(child.lua_get('_G.fixture.called'), 'choose_fzf_menu')
 end
 
 T['create_diff_menu_pane()']['opens fzf menu when mods count exceeds threshold'] = function()
-    local sorted, names = make_files(10)
-    child.lua([[
+  local sorted, names = make_files(10)
+  child.lua([[
         local sorted, names = ...
         _G.fixture.sorted_files = sorted
         _G.fixture.mods = names
@@ -309,7 +352,7 @@ T['create_diff_menu_pane()']['opens fzf menu when mods count exceeds threshold']
         M.create_diff_menu_pane('HEAD')
     ]], { sorted, names })
 
-    eq(child.lua_get('_G.fixture.called'), 'choose_fzf_menu')
+  eq(child.lua_get('_G.fixture.called'), 'choose_fzf_menu')
 end
 
 return T

--- a/tests/deltaview/test_picker.lua
+++ b/tests/deltaview/test_picker.lua
@@ -7,10 +7,10 @@ local child = MiniTest.new_child_neovim()
 -- setup
 
 local T = new_set({
-    hooks = {
-        pre_case = function()
-            child.restart({ '-u', 'scripts/minimal_init.lua' })
-            child.lua([[
+  hooks = {
+    pre_case = function()
+      child.restart({ '-u', 'scripts/minimal_init.lua' })
+      child.lua([[
                 package.loaded['deltaview.utils'] = {
                     get_adjacent_files = function(_diffed_files) return nil end,
                     get_sorted_diffed_files = function(_ref) return {} end,
@@ -50,19 +50,19 @@ local T = new_set({
 
                 M = require('deltaview.picker')
             ]])
-            child.lua([[_G.fixture = {}]])
-        end,
-        post_once = child.stop,
-    },
+      child.lua([[_G.fixture = {}]])
+    end,
+    post_once = child.stop,
+  },
 })
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- decorate_deltaview_with_next_keybinds() - example based tests
 
 T['decorate_deltaview_with_next_keybinds()'] = new_set({
-    hooks = {
-        pre_case = function()
-            child.lua([[
+  hooks = {
+    pre_case = function()
+      child.lua([[
                 -- Create a real scratch buffer so buf_get/set_name work normally.
                 local bufnr = vim.api.nvim_create_buf(true, true)
                 vim.api.nvim_buf_set_name(bufnr, 'myfile.lua')
@@ -90,13 +90,13 @@ T['decorate_deltaview_with_next_keybinds()'] = new_set({
                     cur_idx = 2,
                 }
             ]])
-        end,
-    },
+    end,
+  },
 })
 
 -- adjacent_files is nil: nothing should happen
 T['decorate_deltaview_with_next_keybinds()']['does nothing when adjacent_files is nil'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.utils'].get_adjacent_files = function(_) return nil end
         local original_name = vim.api.nvim_buf_get_name(_G.fixture.bufnr)
         M.decorate_deltaview_with_next_keybinds(_G.fixture.bufnr)
@@ -104,15 +104,15 @@ T['decorate_deltaview_with_next_keybinds()']['does nothing when adjacent_files i
         _G.fixture.original_name = original_name
     ]])
 
-    local original = child.lua_get('_G.fixture.original_name')
-    local after = child.lua_get('_G.fixture.name_after')
-    eq(original, after)
-    eq(child.lua_get('next((_G.fixture.keymap_set_args))'), vim.NIL)
+  local original = child.lua_get('_G.fixture.original_name')
+  local after = child.lua_get('_G.fixture.name_after')
+  eq(original, after)
+  eq(child.lua_get('next((_G.fixture.keymap_set_args))'), vim.NIL)
 end
 
 -- adjacent_files non-nil, show_verbose_nav = false: name includes [idx|total] block, no prev prefix
 T['decorate_deltaview_with_next_keybinds()']['sets buffer name with navigation info when show_verbose_nav is false'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.config'].options.show_verbose_nav = false
         package.loaded['deltaview.utils'].get_adjacent_files = function(_)
             return { prev = 'path/to/a.lua', next = 'path/to/c.lua' }
@@ -121,19 +121,19 @@ T['decorate_deltaview_with_next_keybinds()']['sets buffer name with navigation i
         _G.fixture.name = vim.api.nvim_buf_get_name(_G.fixture.bufnr)
     ]])
 
-    local name = child.lua_get('_G.fixture.name')
-    -- Should contain the [cur|total] index block
-    eq(name:find('%[2|3%]') ~= nil, true)
-    -- Should contain the next file's tail
-    eq(name:find('c%.lua') ~= nil, true)
-    -- Should NOT contain the prev file's tail before the index block (no verbose prefix)
-    local idx_pos = name:find('%[2|3%]')
-    eq(name:sub(1, idx_pos - 1):find('a%.lua'), nil)
+  local name = child.lua_get('_G.fixture.name')
+  -- Should contain the [cur|total] index block
+  eq(name:find('%[2|3%]') ~= nil, true)
+  -- Should contain the next file's tail
+  eq(name:find('c%.lua') ~= nil, true)
+  -- Should NOT contain the prev file's tail before the index block (no verbose prefix)
+  local idx_pos = name:find('%[2|3%]')
+  eq(name:sub(1, idx_pos - 1):find('a%.lua'), nil)
 end
 
 -- adjacent_files non-nil, show_verbose_nav = true: name is prefixed with prev filename + prev icon
 T['decorate_deltaview_with_next_keybinds()']['prefixes buffer name with prev filename when show_verbose_nav is true'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.config'].options.show_verbose_nav = true
         package.loaded['deltaview.utils'].get_adjacent_files = function(_)
             return { prev = 'path/to/a.lua', next = 'path/to/c.lua' }
@@ -142,51 +142,51 @@ T['decorate_deltaview_with_next_keybinds()']['prefixes buffer name with prev fil
         _G.fixture.name = vim.api.nvim_buf_get_name(_G.fixture.bufnr)
     ]])
 
-    local name = child.lua_get('_G.fixture.name')
-    -- Both prev and next file tails should appear
-    eq(name:find('a%.lua') ~= nil, true)
-    eq(name:find('c%.lua') ~= nil, true)
-    -- prev tail should appear before the [idx|total] block
-    local prev_pos = name:find('a%.lua')
-    local idx_pos = name:find('%[2|3%]')
-    eq(prev_pos < idx_pos, true)
+  local name = child.lua_get('_G.fixture.name')
+  -- Both prev and next file tails should appear
+  eq(name:find('a%.lua') ~= nil, true)
+  eq(name:find('c%.lua') ~= nil, true)
+  -- prev tail should appear before the [idx|total] block
+  local prev_pos = name:find('a%.lua')
+  local idx_pos = name:find('%[2|3%]')
+  eq(prev_pos < idx_pos, true)
 end
 
 -- next_diff keybind is registered with the correct mode, buffer, and silent options
 T['decorate_deltaview_with_next_keybinds()']['registers next_diff keybind on the correct buffer'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.utils'].get_adjacent_files = function(_)
             return { prev = 'path/to/a.lua', next = 'path/to/c.lua' }
         end
         M.decorate_deltaview_with_next_keybinds(_G.fixture.bufnr)
     ]])
 
-    -- Read serializable fields one at a time to avoid the child trying to serialize `rhs` (a function).
-    eq(child.lua_get("_G.fixture.keymap_set_args[']d'].mode"), 'n')
-    eq(child.lua_get("_G.fixture.keymap_set_args[']d'].lhs"), ']d')
-    eq(child.lua_get("_G.fixture.keymap_set_args[']d'].opts.buffer"), child.lua_get('_G.fixture.bufnr'))
-    eq(child.lua_get("_G.fixture.keymap_set_args[']d'].opts.silent"), true)
+  -- Read serializable fields one at a time to avoid the child trying to serialize `rhs` (a function).
+  eq(child.lua_get("_G.fixture.keymap_set_args[']d'].mode"), 'n')
+  eq(child.lua_get("_G.fixture.keymap_set_args[']d'].lhs"), ']d')
+  eq(child.lua_get("_G.fixture.keymap_set_args[']d'].opts.buffer"), child.lua_get('_G.fixture.bufnr'))
+  eq(child.lua_get("_G.fixture.keymap_set_args[']d'].opts.silent"), true)
 end
 
 -- prev_diff keybind is registered with the correct mode, buffer, and silent options
 T['decorate_deltaview_with_next_keybinds()']['registers prev_diff keybind on the correct buffer'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.utils'].get_adjacent_files = function(_)
             return { prev = 'path/to/a.lua', next = 'path/to/c.lua' }
         end
         M.decorate_deltaview_with_next_keybinds(_G.fixture.bufnr)
     ]])
 
-    -- Read serializable fields one at a time to avoid the child trying to serialize `rhs` (a function).
-    eq(child.lua_get("_G.fixture.keymap_set_args['[d'].mode"), 'n')
-    eq(child.lua_get("_G.fixture.keymap_set_args['[d'].lhs"), '[d')
-    eq(child.lua_get("_G.fixture.keymap_set_args['[d'].opts.buffer"), child.lua_get('_G.fixture.bufnr'))
-    eq(child.lua_get("_G.fixture.keymap_set_args['[d'].opts.silent"), true)
+  -- Read serializable fields one at a time to avoid the child trying to serialize `rhs` (a function).
+  eq(child.lua_get("_G.fixture.keymap_set_args['[d'].mode"), 'n')
+  eq(child.lua_get("_G.fixture.keymap_set_args['[d'].lhs"), '[d')
+  eq(child.lua_get("_G.fixture.keymap_set_args['[d'].opts.buffer"), child.lua_get('_G.fixture.bufnr'))
+  eq(child.lua_get("_G.fixture.keymap_set_args['[d'].opts.silent"), true)
 end
 
 -- next_diff keybind rhs calls programmatically_select_diff_from_menu with adjacent_files.next
 T['decorate_deltaview_with_next_keybinds()']['next_diff keybind navigates to the next adjacent file'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.utils'].get_adjacent_files = function(_)
             return { prev = 'path/to/a.lua', next = 'path/to/c.lua' }
         end
@@ -195,12 +195,12 @@ T['decorate_deltaview_with_next_keybinds()']['next_diff keybind navigates to the
         _G.fixture.keymap_set_args[']d'].rhs()
     ]])
 
-    eq(child.lua_get('_G.fixture.programmatically_selected'), 'path/to/c.lua')
+  eq(child.lua_get('_G.fixture.programmatically_selected'), 'path/to/c.lua')
 end
 
 -- prev_diff keybind rhs calls programmatically_select_diff_from_menu with adjacent_files.prev
 T['decorate_deltaview_with_next_keybinds()']['prev_diff keybind navigates to the previous adjacent file'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.utils'].get_adjacent_files = function(_)
             return { prev = 'path/to/a.lua', next = 'path/to/c.lua' }
         end
@@ -209,16 +209,16 @@ T['decorate_deltaview_with_next_keybinds()']['prev_diff keybind navigates to the
         _G.fixture.keymap_set_args['[d'].rhs()
     ]])
 
-    eq(child.lua_get('_G.fixture.programmatically_selected'), 'path/to/a.lua')
+  eq(child.lua_get('_G.fixture.programmatically_selected'), 'path/to/a.lua')
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- programmatically_select_diff_from_menu() - example based tests
 
 T['programmatically_select_diff_from_menu()'] = new_set({
-    hooks = {
-        pre_case = function()
-            child.lua([[
+  hooks = {
+    pre_case = function()
+      child.lua([[
                 -- Happy-path defaults: in git repo, mods contains 'b.lua' at index 2.
                 vim.system = function(_cmd, _opts)
                     return { wait = function() return { code = 0, stdout = '/repo', stderr = '' } end }
@@ -248,76 +248,76 @@ T['programmatically_select_diff_from_menu()'] = new_set({
                 _G.fixture.mods = { 'a.lua', 'b.lua', 'c.lua' }
                 _G.fixture.deltaview_file_result = 42
             ]])
-        end,
-    },
+    end,
+  },
 })
 
 T['programmatically_select_diff_from_menu()']['notifies and returns when not in a git repository'] = function()
-    child.lua([[
+  child.lua([[
         vim.system = function(_cmd, _opts)
             return { wait = function() return { code = 128, stdout = '', stderr = '' } end }
         end
         M.programmatically_select_diff_from_menu('b.lua')
     ]])
 
-    eq(type(child.lua_get('_G.fixture.notified')), 'string')
-    eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+  eq(type(child.lua_get('_G.fixture.notified')), 'string')
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
 end
 
 T['programmatically_select_diff_from_menu()']['raises when filepath is not found in mods'] = function()
-    child.lua([[
+  child.lua([[
         local ok, _err = pcall(function()
             M.programmatically_select_diff_from_menu('not_in_list.lua')
         end)
         _G.fixture.assert_failed = not ok
     ]])
 
-    eq(child.lua_get('_G.fixture.assert_failed'), true)
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
 end
 
 T['programmatically_select_diff_from_menu()']['updates state and calls decorate on happy path'] = function()
-    child.lua([[
+  child.lua([[
         M.programmatically_select_diff_from_menu('b.lua')
     ]])
 
-    -- state.diffed_files should be updated to the full mods list
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.files"),
-        { 'a.lua', 'b.lua', 'c.lua' })
-    -- cur_idx should be the position of 'b.lua' in mods (index 2)
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 2)
-    -- decorate should have been called with the bufnr returned by deltaview_file
-    eq(child.lua_get('_G.fixture.decorate_called_with'), 42)
+  -- state.diffed_files should be updated to the full mods list
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.files"),
+    { 'a.lua', 'b.lua', 'c.lua' })
+  -- cur_idx should be the position of 'b.lua' in mods (index 2)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 2)
+  -- decorate should have been called with the bufnr returned by deltaview_file
+  eq(child.lua_get('_G.fixture.decorate_called_with'), 42)
 end
 
 T['programmatically_select_diff_from_menu()']['does not update state when deltaview_file returns nil'] = function()
-    child.lua([[
+  child.lua([[
         _G.fixture.deltaview_file_result = nil
         -- Preset a known cur_idx so we can confirm it is left unchanged.
         package.loaded['deltaview.state'].diffed_files.cur_idx = 99
         M.programmatically_select_diff_from_menu('b.lua')
     ]])
 
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
-    eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
 end
 
 T['programmatically_select_diff_from_menu()']['notifies error when the pcall body throws'] = function()
-    child.lua([[
+  child.lua([[
         vim.cmd = function(_) error('disk full') end
         M.programmatically_select_diff_from_menu('b.lua')
     ]])
 
-    eq(type(child.lua_get('_G.fixture.notified')), 'string')
-    eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+  eq(type(child.lua_get('_G.fixture.notified')), 'string')
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- open_deltaview_quickselect_menu() - example based tests
 
 T['open_deltaview_quickselect_menu()'] = new_set({
-    hooks = {
-        pre_case = function()
-            child.lua([[
+  hooks = {
+    pre_case = function()
+      child.lua([[
                 -- Capture ui_select arguments for assertion and to expose on_select.
                 package.loaded['deltaview.selector'].ui_select = function(items, opts, on_select)
                     _G.fixture.ui_select_items = items
@@ -339,112 +339,112 @@ T['open_deltaview_quickselect_menu()'] = new_set({
 
                 _G.fixture.deltaview_file_result = 42
             ]])
-        end,
-    },
+    end,
+  },
 })
 
 T['open_deltaview_quickselect_menu()']['raises when ref is nil'] = function()
-    child.lua([[
+  child.lua([[
         local ok, _err = pcall(function()
             M.open_deltaview_quickselect_menu(nil, {}, {})
         end)
         _G.fixture.assert_failed = not ok
     ]])
 
-    eq(child.lua_get('_G.fixture.assert_failed'), true)
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
 end
 
 T['open_deltaview_quickselect_menu()']['raises when mods is nil'] = function()
-    child.lua([[
+  child.lua([[
         local ok, _err = pcall(function()
             M.open_deltaview_quickselect_menu('HEAD', nil, {})
         end)
         _G.fixture.assert_failed = not ok
     ]])
 
-    eq(child.lua_get('_G.fixture.assert_failed'), true)
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
 end
 
 T['open_deltaview_quickselect_menu()']['raises when changes_data is nil'] = function()
-    child.lua([[
+  child.lua([[
         local ok, _err = pcall(function()
             M.open_deltaview_quickselect_menu('HEAD', {}, nil)
         end)
         _G.fixture.assert_failed = not ok
     ]])
 
-    eq(child.lua_get('_G.fixture.assert_failed'), true)
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
 end
 
 T['open_deltaview_quickselect_menu()']['calls ui_select with mods as items'] = function()
-    child.lua([[
+  child.lua([[
         M.open_deltaview_quickselect_menu('HEAD', { 'a.lua', 'b.lua' }, {})
     ]])
 
-    eq(child.lua_get('_G.fixture.ui_select_items'), { 'a.lua', 'b.lua' })
+  eq(child.lua_get('_G.fixture.ui_select_items'), { 'a.lua', 'b.lua' })
 end
 
 T['open_deltaview_quickselect_menu()']['calls ui_select with prompt containing the ref'] = function()
-    child.lua([[
+  child.lua([[
         M.open_deltaview_quickselect_menu('mybranch', { 'a.lua' }, {})
     ]])
 
-    local prompt = child.lua_get('_G.fixture.ui_select_opts.prompt')
-    eq(prompt:find('mybranch') ~= nil, true)
+  local prompt = child.lua_get('_G.fixture.ui_select_opts.prompt')
+  eq(prompt:find('mybranch') ~= nil, true)
 end
 
 T['open_deltaview_quickselect_menu()']['on_select: does nothing when filepath is nil'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.state'].diffed_files.cur_idx = 99
         M.open_deltaview_quickselect_menu('HEAD', { 'a.lua', 'b.lua' }, {})
         _G.fixture.captured_on_select(nil, 1)
     ]])
 
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
-    eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
 end
 
 T['open_deltaview_quickselect_menu()']['on_select: updates state and calls decorate on happy path'] = function()
-    child.lua([[
+  child.lua([[
         M.open_deltaview_quickselect_menu('HEAD', { 'a.lua', 'b.lua', 'c.lua' }, {})
         _G.fixture.captured_on_select('b.lua', 2)
     ]])
 
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.files"), { 'a.lua', 'b.lua', 'c.lua' })
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 2)
-    eq(child.lua_get('_G.fixture.decorate_called_with'), 42)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.files"), { 'a.lua', 'b.lua', 'c.lua' })
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 2)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), 42)
 end
 
 T['open_deltaview_quickselect_menu()']['on_select: does not update state when deltaview_file returns nil'] = function()
-    child.lua([[
+  child.lua([[
         _G.fixture.deltaview_file_result = nil
         package.loaded['deltaview.state'].diffed_files.cur_idx = 99
         M.open_deltaview_quickselect_menu('HEAD', { 'a.lua', 'b.lua' }, {})
         _G.fixture.captured_on_select('b.lua', 2)
     ]])
 
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
-    eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
 end
 
 T['open_deltaview_quickselect_menu()']['on_select: notifies error when pcall body throws'] = function()
-    child.lua([[
+  child.lua([[
         vim.cmd = function(_) error('disk full') end
         M.open_deltaview_quickselect_menu('HEAD', { 'a.lua', 'b.lua' }, {})
         _G.fixture.captured_on_select('b.lua', 2)
     ]])
 
-    eq(type(child.lua_get('_G.fixture.notified')), 'string')
-    eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+  eq(type(child.lua_get('_G.fixture.notified')), 'string')
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- open_deltaview_fzf_lua_menu() - example based tests
 
 T['open_deltaview_fzf_lua_menu()'] = new_set({
-    hooks = {
-        pre_case = function()
-            child.lua([[
+  hooks = {
+    pre_case = function()
+      child.lua([[
                 -- Stub builtin previewer base with a minimal class that supports :extend().
                 local base_stub = {}
                 base_stub.extend = function(self)
@@ -477,75 +477,75 @@ T['open_deltaview_fzf_lua_menu()'] = new_set({
 
                 _G.fixture.deltaview_file_result = 42
             ]])
-        end,
-    },
+    end,
+  },
 })
 
 T['open_deltaview_fzf_lua_menu()']['calls fzf_exec with mods as items'] = function()
-    child.lua([[
+  child.lua([[
         M.open_deltaview_fzf_lua_menu('HEAD', { 'a.lua', 'b.lua' }, {})
     ]])
 
-    eq(child.lua_get('_G.fixture.fzf_exec_items'), { 'a.lua', 'b.lua' })
+  eq(child.lua_get('_G.fixture.fzf_exec_items'), { 'a.lua', 'b.lua' })
 end
 
 T['open_deltaview_fzf_lua_menu()']['calls fzf_exec with winopts title containing diff_target_ref'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.state'].diff_target_ref = 'mybranch'
         M.open_deltaview_fzf_lua_menu('HEAD', { 'a.lua' }, {})
     ]])
 
-    local title = child.lua_get('_G.fixture.fzf_exec_title')
-    eq(title:find('mybranch') ~= nil, true)
+  local title = child.lua_get('_G.fixture.fzf_exec_title')
+  eq(title:find('mybranch') ~= nil, true)
 end
 
 T['open_deltaview_fzf_lua_menu()']['default action: does nothing when selected is nil'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.state'].diffed_files.cur_idx = 99
         M.open_deltaview_fzf_lua_menu('HEAD', { 'a.lua', 'b.lua' }, {})
         _G.fixture.captured_default_action(nil)
     ]])
 
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
-    eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
 end
 
 T['open_deltaview_fzf_lua_menu()']['default action: does nothing when selected is empty'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.state'].diffed_files.cur_idx = 99
         M.open_deltaview_fzf_lua_menu('HEAD', { 'a.lua', 'b.lua' }, {})
         _G.fixture.captured_default_action({})
     ]])
 
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
-    eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
 end
 
 T['open_deltaview_fzf_lua_menu()']['default action: updates state and calls decorate on happy path'] = function()
-    child.lua([[
+  child.lua([[
         M.open_deltaview_fzf_lua_menu('HEAD', { 'a.lua', 'b.lua', 'c.lua' }, {})
         _G.fixture.captured_default_action({ 'b.lua' })
     ]])
 
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.files"), { 'a.lua', 'b.lua', 'c.lua' })
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 2)
-    eq(child.lua_get('_G.fixture.decorate_called_with'), 42)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.files"), { 'a.lua', 'b.lua', 'c.lua' })
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 2)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), 42)
 end
 
 T['open_deltaview_fzf_lua_menu()']['default action: does not update state when deltaview_file returns nil'] = function()
-    child.lua([[
+  child.lua([[
         _G.fixture.deltaview_file_result = nil
         package.loaded['deltaview.state'].diffed_files.cur_idx = 99
         M.open_deltaview_fzf_lua_menu('HEAD', { 'a.lua', 'b.lua' }, {})
         _G.fixture.captured_default_action({ 'b.lua' })
     ]])
 
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
-    eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
 end
 
 T['open_deltaview_fzf_lua_menu()']['default action: raises when selection not found in mods'] = function()
-    child.lua([[
+  child.lua([[
         M.open_deltaview_fzf_lua_menu('HEAD', { 'a.lua', 'b.lua' }, {})
         local ok, _err = pcall(function()
             _G.fixture.captured_default_action({ 'not_in_list.lua' })
@@ -553,16 +553,16 @@ T['open_deltaview_fzf_lua_menu()']['default action: raises when selection not fo
         _G.fixture.assert_failed = not ok
     ]])
 
-    eq(child.lua_get('_G.fixture.assert_failed'), true)
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- open_deltaview_telescope_menu() - example based tests
 
 T['open_deltaview_telescope_menu()'] = new_set({
-    hooks = {
-        pre_case = function()
-            child.lua([[
+  hooks = {
+    pre_case = function()
+      child.lua([[
                 package.loaded['telescope'] = {}
 
                 package.loaded['telescope.finders'] = {
@@ -620,89 +620,89 @@ T['open_deltaview_telescope_menu()'] = new_set({
 
                 _G.fixture.deltaview_file_result = 42
             ]])
-        end,
-    },
+    end,
+  },
 })
 
 T['open_deltaview_telescope_menu()']['raises when ref is nil'] = function()
-    child.lua([[
+  child.lua([[
         local ok, _err = pcall(function()
             M.open_deltaview_telescope_menu(nil, {}, {})
         end)
         _G.fixture.assert_failed = not ok
     ]])
 
-    eq(child.lua_get('_G.fixture.assert_failed'), true)
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
 end
 
 T['open_deltaview_telescope_menu()']['raises when mods is nil'] = function()
-    child.lua([[
+  child.lua([[
         local ok, _err = pcall(function()
             M.open_deltaview_telescope_menu('HEAD', nil, {})
         end)
         _G.fixture.assert_failed = not ok
     ]])
 
-    eq(child.lua_get('_G.fixture.assert_failed'), true)
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
 end
 
 T['open_deltaview_telescope_menu()']['raises when changes_data is nil'] = function()
-    child.lua([[
+  child.lua([[
         local ok, _err = pcall(function()
             M.open_deltaview_telescope_menu('HEAD', {}, nil)
         end)
         _G.fixture.assert_failed = not ok
     ]])
 
-    eq(child.lua_get('_G.fixture.assert_failed'), true)
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
 end
 
 T['open_deltaview_telescope_menu()']['passes mods as finder results'] = function()
-    child.lua([[
+  child.lua([[
         M.open_deltaview_telescope_menu('HEAD', { 'a.lua', 'b.lua' }, {})
     ]])
 
-    eq(child.lua_get('_G.fixture.finder_results'), { 'a.lua', 'b.lua' })
+  eq(child.lua_get('_G.fixture.finder_results'), { 'a.lua', 'b.lua' })
 end
 
 T['open_deltaview_telescope_menu()']['results_title contains diff_target_ref'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.state'].diff_target_ref = 'mybranch'
         M.open_deltaview_telescope_menu('HEAD', { 'a.lua' }, {})
     ]])
 
-    local title = child.lua_get('_G.fixture.results_title')
-    eq(title:find('mybranch') ~= nil, true)
+  local title = child.lua_get('_G.fixture.results_title')
+  eq(title:find('mybranch') ~= nil, true)
 end
 
 -- select_default handler tests — invoke _G.fixture.captured_select_handler directly
 
 T['open_deltaview_telescope_menu()']['select_default: does nothing when get_selected_entry returns nil'] = function()
-    child.lua([[
+  child.lua([[
         package.loaded['deltaview.state'].diffed_files.cur_idx = 99
         _G.fixture.selected_entry = nil
         M.open_deltaview_telescope_menu('HEAD', { 'a.lua', 'b.lua' }, {})
         _G.fixture.captured_select_handler()
     ]])
 
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
-    eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
 end
 
 T['open_deltaview_telescope_menu()']['select_default: updates state and calls decorate on happy path'] = function()
-    child.lua([[
+  child.lua([[
         _G.fixture.selected_entry = { value = 'b.lua' }
         M.open_deltaview_telescope_menu('HEAD', { 'a.lua', 'b.lua', 'c.lua' }, {})
         _G.fixture.captured_select_handler()
     ]])
 
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.files"), { 'a.lua', 'b.lua', 'c.lua' })
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 2)
-    eq(child.lua_get('_G.fixture.decorate_called_with'), 42)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.files"), { 'a.lua', 'b.lua', 'c.lua' })
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 2)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), 42)
 end
 
 T['open_deltaview_telescope_menu()']['select_default: raises when selection not found in mods'] = function()
-    child.lua([[
+  child.lua([[
         _G.fixture.selected_entry = { value = 'not_in_list.lua' }
         M.open_deltaview_telescope_menu('HEAD', { 'a.lua', 'b.lua' }, {})
         local ok, _err = pcall(function()
@@ -711,11 +711,11 @@ T['open_deltaview_telescope_menu()']['select_default: raises when selection not 
         _G.fixture.assert_failed = not ok
     ]])
 
-    eq(child.lua_get('_G.fixture.assert_failed'), true)
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
 end
 
 T['open_deltaview_telescope_menu()']['select_default: does not update state when deltaview_file returns nil'] = function()
-    child.lua([[
+  child.lua([[
         _G.fixture.deltaview_file_result = nil
         _G.fixture.selected_entry = { value = 'b.lua' }
         package.loaded['deltaview.state'].diffed_files.cur_idx = 99
@@ -723,20 +723,197 @@ T['open_deltaview_telescope_menu()']['select_default: does not update state when
         _G.fixture.captured_select_handler()
     ]])
 
-    eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
-    eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
 end
 
 T['open_deltaview_telescope_menu()']['select_default: notifies error when pcall body throws'] = function()
-    child.lua([[
+  child.lua([[
         vim.cmd = function(_) error('disk full') end
         _G.fixture.selected_entry = { value = 'b.lua' }
         M.open_deltaview_telescope_menu('HEAD', { 'a.lua', 'b.lua' }, {})
         _G.fixture.captured_select_handler()
     ]])
 
-    eq(type(child.lua_get('_G.fixture.notified')), 'string')
-    eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+  eq(type(child.lua_get('_G.fixture.notified')), 'string')
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+end
+
+-- ──────────────────────────────────────────────────────────────────────────────────────────────
+-- open_deltaview_snacks_menu() - example based tests
+
+T['open_deltaview_snacks_menu()'] = new_set({
+  hooks = {
+    pre_case = function()
+      child.lua([[
+                package.loaded['snacks'] = {
+                    picker = {
+                        pick = function(opts)
+                            _G.fixture.snacks_opts = opts
+                            _G.fixture.snacks_items = opts.items
+                            _G.fixture.snacks_title = opts.title
+                            _G.fixture.captured_confirm = opts.confirm
+                            _G.fixture.captured_preview = opts.preview
+                        end,
+                    },
+                }
+
+                vim.fn.fnameescape = function(p) return p end
+                vim.fn.fnamemodify = function(path, _mod)
+                    return path:match('([^/]+)$') or path
+                end
+                vim.cmd = function(_) end
+                package.loaded['deltaview.utils'].git_rel_to_abs = function(p) return p end
+                package.loaded['deltaview.view'].deltaview_file = function(_ref)
+                    return _G.fixture.deltaview_file_result
+                end
+                package.loaded['deltaview.view'].open_git_diff_buffer_for_path = function(_filepath, _ref, _context, winid, _suffix)
+                    _G.fixture.preview_winid = winid
+                    return _G.fixture.preview_bufnr
+                end
+
+                M.decorate_deltaview_with_next_keybinds = function(bufnr)
+                    _G.fixture.decorate_called_with = bufnr
+                end
+
+                _G.fixture.deltaview_file_result = 42
+                _G.fixture.preview_bufnr = 43
+            ]])
+    end,
+  },
+})
+
+T['open_deltaview_snacks_menu()']['raises when ref is nil'] = function()
+  child.lua([[
+        local ok, _err = pcall(function()
+            M.open_deltaview_snacks_menu(nil, {}, {})
+        end)
+        _G.fixture.assert_failed = not ok
+    ]])
+
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
+end
+
+T['open_deltaview_snacks_menu()']['raises when mods is nil'] = function()
+  child.lua([[
+        local ok, _err = pcall(function()
+            M.open_deltaview_snacks_menu('HEAD', nil, {})
+        end)
+        _G.fixture.assert_failed = not ok
+    ]])
+
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
+end
+
+T['open_deltaview_snacks_menu()']['raises when changes_data is nil'] = function()
+  child.lua([[
+        local ok, _err = pcall(function()
+            M.open_deltaview_snacks_menu('HEAD', {}, nil)
+        end)
+        _G.fixture.assert_failed = not ok
+    ]])
+
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
+end
+
+T['open_deltaview_snacks_menu()']['passes mods as snacks picker items'] = function()
+  child.lua([[
+        M.open_deltaview_snacks_menu('HEAD', { 'a.lua', 'b.lua' }, {})
+    ]])
+
+  eq(child.lua_get('_G.fixture.snacks_items[1].value'), 'a.lua')
+  eq(child.lua_get('_G.fixture.snacks_items[2].value'), 'b.lua')
+end
+
+T['open_deltaview_snacks_menu()']['title contains DeltaView Menu'] = function()
+  child.lua([[
+        M.open_deltaview_snacks_menu('HEAD', { 'a.lua' }, {})
+    ]])
+
+  eq(child.lua_get('_G.fixture.snacks_title'), 'DeltaView Menu')
+end
+
+T['open_deltaview_snacks_menu()']['confirm: does nothing when item is nil'] = function()
+  child.lua([[
+        package.loaded['deltaview.state'].diffed_files.cur_idx = 99
+        M.open_deltaview_snacks_menu('HEAD', { 'a.lua', 'b.lua' }, {})
+        _G.fixture.captured_confirm({ close = function() _G.fixture.closed = true end }, nil)
+    ]])
+
+  eq(child.lua_get('_G.fixture.closed'), true)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+end
+
+T['open_deltaview_snacks_menu()']['confirm: updates state and calls decorate on happy path'] = function()
+  child.lua([[
+        M.open_deltaview_snacks_menu('HEAD', { 'a.lua', 'b.lua', 'c.lua' }, {})
+        _G.fixture.captured_confirm({ close = function() _G.fixture.closed = true end }, { value = 'b.lua' })
+    ]])
+
+  eq(child.lua_get('_G.fixture.closed'), true)
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.files"), { 'a.lua', 'b.lua', 'c.lua' })
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 2)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), 42)
+end
+
+T['open_deltaview_snacks_menu()']['confirm: raises when selection not found in mods'] = function()
+  child.lua([[
+        M.open_deltaview_snacks_menu('HEAD', { 'a.lua', 'b.lua' }, {})
+        local ok, _err = pcall(function()
+            _G.fixture.captured_confirm({ close = function() end }, { value = 'not_in_list.lua' })
+        end)
+        _G.fixture.assert_failed = not ok
+    ]])
+
+  eq(child.lua_get('_G.fixture.assert_failed'), true)
+end
+
+T['open_deltaview_snacks_menu()']['confirm: does not update state when deltaview_file returns nil'] = function()
+  child.lua([[
+        _G.fixture.deltaview_file_result = nil
+        package.loaded['deltaview.state'].diffed_files.cur_idx = 99
+        M.open_deltaview_snacks_menu('HEAD', { 'a.lua', 'b.lua' }, {})
+        _G.fixture.captured_confirm({ close = function() end }, { value = 'b.lua' })
+    ]])
+
+  eq(child.lua_get("package.loaded['deltaview.state'].diffed_files.cur_idx"), 99)
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+end
+
+T['open_deltaview_snacks_menu()']['confirm: notifies error when pcall body throws'] = function()
+  child.lua([[
+        vim.cmd = function(_) error('disk full') end
+        M.open_deltaview_snacks_menu('HEAD', { 'a.lua', 'b.lua' }, {})
+        _G.fixture.captured_confirm({ close = function() end }, { value = 'b.lua' })
+    ]])
+
+  eq(type(child.lua_get('_G.fixture.notified')), 'string')
+  eq(child.lua_get('_G.fixture.decorate_called_with'), vim.NIL)
+end
+
+T['open_deltaview_snacks_menu()']['preview: opens deltaview diff buffer in snacks preview window'] = function()
+  child.lua([[
+        local preview_buf = vim.api.nvim_create_buf(false, true)
+        _G.fixture.preview_bufnr = preview_buf
+        M.open_deltaview_snacks_menu('HEAD', { 'dir/a.lua' }, { ['dir/a.lua'] = { '+1,-0' } })
+        _G.fixture.preview_ctx = {
+            item = { value = 'dir/a.lua' },
+            win = 1000,
+            preview = {
+                set_buf = function(_, bufnr) _G.fixture.preview_set_buf = bufnr end,
+                set_title = function(_, title) _G.fixture.preview_title = title end,
+                wo = function(_, opts) _G.fixture.preview_wo = opts end,
+                set_lines = function(_, lines) _G.fixture.preview_lines = lines end,
+            },
+        }
+        _G.fixture.captured_preview(_G.fixture.preview_ctx)
+    ]])
+
+  eq(child.lua_get('_G.fixture.preview_winid'), false)
+  eq(child.lua_get('_G.fixture.preview_set_buf'), child.lua_get('_G.fixture.preview_bufnr'))
+  eq(child.lua_get('_G.fixture.preview_title'):find('a.lua') ~= nil, true)
+  eq(child.lua_get('_G.fixture.preview_wo.wrap'), true)
 end
 
 return T


### PR DESCRIPTION
- Add a Snacks picker backend for DeltaMenu with formatted file entries, diff previews, and selection handling.
- Route `fzf_picker = "snacks"` through the picker selection logic.
- Include snacks.nvim in automatic picker detection after fzf-lua and telescope, before falling back to the built-in quickselect UI.
- Update health checks to report snacks.nvim availability and active picker resolution.
- Allow diff buffers to be created without immediately assigning them to a window, so Snacks can safely own preview window buffer updates.
- Update configuration docs and README examples to include the new `snacks` picker option.
- Remove snacks.nvim from the roadmap now that it is supported.
- Add unit tests for snacks picker routing, confirmation behavior, preview buffer creation, and fallback behavior.


NOTE: to be honest, i don't lua or how neovim plugins work.I liked your plugin so tried to contribute anyways. I used `codex` for it and add support for snacks.nvim picker