### PR TITLE
Pass --no-ext-diff to all git diff invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,18 @@ I will keep the version in "Latest" as not a tag, to be extendable for bug fixes
 
 ## Latest
 
-### [0.3.0] - 2026-05-20 to ongoing
+### [0.3.1] - 2026-05-26 to ongoing
 
-- initial commit - https://github.com/kokusenz/deltaview.nvim/pull/39
+- initial commit - https://github.com/kokusenz/deltaview.nvim/pull/41
+
+#### Fixes
+- `--no-ext-diff` is passed as a flag into all git diff invocations, to avoid crashing with diff.external configuration (such as difftastic).
+
+## History
+
+### [0.3.0] - 2026-05-20 to 2026-05-26
+
+- initial commit - 8940ac8340987ca4efafd386521c2c21b3ca79ae 
 
 #### Added
 
@@ -32,8 +41,6 @@ I will keep the version in "Latest" as not a tag, to be extendable for bug fixes
 - `register_ui_select` was deprecated (allowing the user to use the quickselect ui for their vim.ui.select)
 - fzf_threshold in configuration was fully removed (user experience driven decision)
 - show_verbose_nav in configuration was fully removed, in favor of the quickfix list workflow
-
-## History
 
 ### [0.2.3] - 2026-04-28 to 2026-05-20
 

--- a/lua/deltaview/utils.lua
+++ b/lua/deltaview/utils.lua
@@ -41,7 +41,7 @@ end
 --- @return string[] array of file paths that have been modified or are untracked
 M.get_diffed_files = function(ref)
     assert(ref ~= nil)
-    local result = vim.system({'git', 'diff', ref, '--name-only'}):wait()
+    local result = vim.system({'git', 'diff', '--no-ext-diff', ref, '--name-only'}):wait()
     if result.code ~= 0 and result.code ~= 1 then
         vim.notify('Failed to get diff files from git.', vim.log.levels.ERROR)
         return {}
@@ -88,7 +88,7 @@ end
 M.get_sorted_diffed_files = function(ref)
     assert(ref ~= nil)
     local files = M.get_diffed_and_untracked_files(ref)
-    local dirstat_result = vim.system({'git', 'diff', ref, '-X', '--dirstat=lines,0'}):wait()
+    local dirstat_result = vim.system({'git', 'diff', '--no-ext-diff', ref, '-X', '--dirstat=lines,0'}):wait()
     if dirstat_result.code ~= 0 and dirstat_result.code ~= 1 then
         vim.notify('Failed to get diff dirstat from git.', vim.log.levels.ERROR)
         return {}
@@ -103,7 +103,7 @@ M.get_sorted_diffed_files = function(ref)
         end
     end
 
-    local name_status_result = vim.system({'git', 'diff', '--name-status', ref}):wait()
+    local name_status_result = vim.system({'git', 'diff', '--no-ext-diff', '--name-status', ref}):wait()
     local file_statuses = {}
     if name_status_result.code == 0 or name_status_result.code == 1 then
         for line in name_status_result.stdout:gmatch('[^\n]+') do
@@ -124,9 +124,9 @@ M.get_sorted_diffed_files = function(ref)
 
         if tracked == false then
             -- untracked files have no git history; count all lines as added
-            numstat_result = vim.system({'git', 'diff', '--numstat', '--no-index', '--', '/dev/null', M.git_rel_to_abs(file)}):wait()
+            numstat_result = vim.system({'git', 'diff', '--no-ext-diff', '--numstat', '--no-index', '--', '/dev/null', M.git_rel_to_abs(file)}):wait()
         else
-            numstat_result = vim.system({'git', 'diff', '--numstat', ref, '--', M.git_rel_to_abs(file)}):wait()
+            numstat_result = vim.system({'git', 'diff', '--no-ext-diff', '--numstat', ref, '--', M.git_rel_to_abs(file)}):wait()
         end
         assert(numstat_result.code == 0 or numstat_result.code == 1)
         -- git diff --numstat outputs "-\t-\t<path>" for binary files; explicitly

--- a/lua/deltaview/view.lua
+++ b/lua/deltaview/view.lua
@@ -86,7 +86,7 @@ M.open_git_diff_buffer = function(filepath, ref, winnr)
     local git_data
 
     if is_untracked ~= true then
-        local diff_result = vim.system({ 'git', '-C', git_root, 'diff', '-U0', ref, '--', filepath }):wait()
+        local diff_result = vim.system({ 'git', '-C', git_root, 'diff', '--no-ext-diff', '-U0', ref, '--', filepath }):wait()
         if diff_result.code ~= 0 and diff_result.code ~= 1 then
             vim.notify('Failed to run git diff - ' .. diff_result.stderr, vim.log.levels.ERROR)
             return

--- a/tests/deltaview/test_utils.lua
+++ b/tests/deltaview/test_utils.lua
@@ -560,8 +560,12 @@ T['get_diffed_files()']['captures the ref passed to the git command'] = function
     ]])
     child.lua_get([[M.get_diffed_files('main~3')]])
     local cmd = child.lua_get([[_G.fixture.captured_cmd]])
-    eq(cmd[2], 'diff')
-    eq(cmd[3], 'main~3')
+    local found = {}
+    for _, text in ipairs(cmd) do
+        found[text] = true
+    end
+    eq(found['diff'], true)
+    eq(found['main~3'], true)
 end
 
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
@@ -748,16 +752,20 @@ T['get_sorted_diffed_files()'] = new_set({
                     -- 3. numstat (tracked):   {'git', 'diff', '--numstat', ref, '--', abs_path}
                     -- 4. numstat (untracked): {'git', 'diff', '--numstat', '--no-index', '--', '/dev/null', abs_path}
                     local stdout
-                    if cmd[1] == 'git' and cmd[2] == 'diff' and cmd[4] == '-X' then
+                    local found = {}
+                    for _, text in ipairs(cmd) do
+                        found[text] = true
+                    end
+                    if found['git'] == true and found['diff'] == true and found['-X'] == true then
                         -- dirstat call
                         stdout = _G.fixture.dirstat_out or ''
-                    elseif cmd[1] == 'git' and cmd[2] == 'diff' and cmd[3] == '--name-status' then
+                    elseif found['git'] == true and found['diff'] == true and found['--name-status'] == true then
                         -- name-status call
                         stdout = _G.fixture.name_status_out or ''
-                    elseif cmd[1] == 'git' and cmd[2] == 'diff' and cmd[3] == '--numstat' then
+                    elseif found['git'] == true and found['diff'] == true and found['--numstat'] == true then
                         -- untracked: {'git','diff','--numstat','--no-index','--','/dev/null', abs_path}  -> cmd[7]
                         -- tracked:   {'git','diff','--numstat', ref,         '--', abs_path}            -> cmd[6]
-                        local abs_path = (cmd[4] == '--no-index') and cmd[7] or cmd[6]
+                        local abs_path = cmd[#cmd]
                         local numstat_map = _G.fixture.numstat_map or {}
                         stdout = numstat_map[abs_path] or '0\t0\t' .. abs_path .. '\n'
                     else

--- a/tests/deltaview/test_view.lua
+++ b/tests/deltaview/test_view.lua
@@ -67,9 +67,13 @@ local T = new_set({
                 -- mocking shell functions, assuming success here.
                 vim.system = function(cmd, _opts)
                     local stdout = ''
-                    if _cmd[1] == 'git' and _cmd[2] == 'rev-parse' and _cmd[3] == '--show-toplevel' then
+                    local found = {}
+                    for _, text in ipairs(_cmd) do
+                        found[text] = true
+                    end
+                    if found['git'] == true and found['rev-parse'] == true then
                         stdout = '/home/exampleuser/example'
-                    elseif _cmd[1] == 'git' and _cmd[2] == 'diff' and _cmd[3] == '-U0' then
+                    elseif found['git'] == true and found['diff'] == true then
                         local single_file_git_diff = table.concat({
                             "diff --git a/foo.lua b/foo.lua",
                             "index abc1234..def5678 100644",
@@ -261,13 +265,17 @@ local open_git_diff_buffer_happy_mocks = [=[
 
     vim.system = function(cmd, _opts)
         local stdout, code = '', 0
-        if cmd[4] == 'diff' then
-            if cmd[#cmd] == 'a' and cmd[6] ~= 'y' then
+        local found = {}
+        for _, text in ipairs(cmd) do
+            found[text] = true
+        end
+        if found['git'] == true and found['diff'] == true then
+            if found['a'] == true and not found['y'] then
                 stdout = 'a valid non-empty diff string'
             else
                 code = 128
             end
-        elseif cmd[4] == 'cat-file' then
+        elseif found['git'] == true and found['cat-file'] == true then
             code = 128
         end
         return { wait = function() return { code = code, stdout = stdout, stderr = 'err' } end }


### PR DESCRIPTION
## Summary

When a user has `diff.external` set in their gitconfig (e.g. [difftastic](https://github.com/Wilfred/difftastic)), `:DeltaView` crashes with:

```
Failed to open DeltaView - .../deltaview/view.lua:111: attempt to concatenate field 'new_path' (a nil value)
```

### Root cause

`git diff` honors `diff.external` and substitutes the configured tool's output (which is *not* unified diff) in place of the standard format. `delta.lua`'s parser scans for `+++ b/<path>` lines to populate `new_path`; with difftastic (or any other external diff) those lines never appear, so `new_path` stays `nil`. `view.lua:111` then does:

```lua
local file_lines = utils.read_file_lines(git_root .. '/' .. git_data[1].new_path)
```

…and concatenates `nil`.

### Fix

Pass `--no-ext-diff` to every `git diff` invocation in deltaview. This tells git to ignore `diff.external` for *this specific call* — the parser always receives real unified-diff output — while leaving the user's regular `git diff` workflow untouched.

Five call sites updated:
- `lua/deltaview/view.lua` — primary diff used for the view
- `lua/deltaview/utils.lua` — `--name-only`, `--dirstat`, `--name-status`, and two `--numstat` calls

### Test plan

- [x] Reproduced original crash with `[diff] external = difft` in `~/.gitconfig`
- [x] After patch, `:DeltaView` opens normally with the same gitconfig
- [x] No behavioral change for users without `diff.external` set