### PR TITLE
perf: cache fzf-lua DeltaMenu previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 todo/
 deps/
 .luarc.json
-.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 todo/
 deps/
 .luarc.json
+.worktrees/

--- a/doc/deltaview.txt
+++ b/doc/deltaview.txt
@@ -130,4 +130,3 @@ When the DeltaMenu quickfix list is open (:DeltaMenu!):
 | `]q` | Open next file and view its diff |
 | `[q` | Open previous file and view its diff |
 | `:colder` or `:cex []` | Restore previous quickfix list, exiting the DeltaMenu workflow |
-

--- a/lua/deltaview/menu.lua
+++ b/lua/deltaview/menu.lua
@@ -28,7 +28,11 @@ local get_modified_files = function(ref)
     --- @type ChangesData
     local changes_data = {}
     for _, value in ipairs(sorted_files) do
-        changes_data[value.name] = { changes = '+' .. value.added .. ',-' .. value.removed, status = value.status }
+        changes_data[value.name] = {
+            changes = '+' .. value.added .. ',-' .. value.removed,
+            status = value.status,
+            is_untracked = value.is_untracked,
+        }
     end
     return { mods = mods, changes_data = changes_data, ref = ref }
 end
@@ -119,6 +123,7 @@ local get_deltaview_qf_list_entries = function(deltamenu_items)
                 show_delta_on_entry = true,
                 ref = deltamenu_items.ref,
                 status = status,
+                is_untracked = deltamenu_items.changes_data[path].is_untracked,
                 changes = deltamenu_items.changes_data[path].changes,
             }
         }
@@ -364,7 +369,7 @@ M.setup_quickfix_deltaview_on_entry()
 
 --- key is filepath, values are tables where key is type of change, value is value
 --- for example, change type "changes" has "+23,-16", and change type "status" has "M", or "D", etc.
---- @alias ChangesData table<string, table<string, string>>
+--- @alias ChangesData table<string, { changes: string, status: Status, is_untracked: boolean }>
 
 --- @class DeltaMenuItems
 --- @field mods string[] list of changed filepaths

--- a/lua/deltaview/menu.lua
+++ b/lua/deltaview/menu.lua
@@ -11,13 +11,14 @@ local help = require('deltaview.help')
 --- @return DeltaMenuItems | nil returns nil if it needs to notify that there is an error
 local get_modified_files = function(ref)
     local rev_parse_result = vim.system({ 'git', 'rev-parse', '--show-toplevel' }):wait()
-    if rev_parse_result.code ~= 0 and rev_parse_result.code ~= 1 then
+    if rev_parse_result.code ~= 0 then
         vim.notify('Not in a git repository. Cannot open DeltaView menu for git.', vim.log.levels.WARN)
         return
     end
 
     assert(ref)
-    local sorted_files = utils.get_sorted_diffed_files(ref)
+    local git_root = vim.trim(rev_parse_result.stdout)
+    local sorted_files = utils.get_sorted_diffed_files(ref, git_root)
     local mods = utils.get_filenames_from_sortedfiles(sorted_files)
 
     if #mods == 0 then
@@ -34,7 +35,7 @@ local get_modified_files = function(ref)
             is_untracked = value.is_untracked,
         }
     end
-    return { mods = mods, changes_data = changes_data, ref = ref }
+    return { mods = mods, changes_data = changes_data, ref = ref, git_root = git_root }
 end
 
 --- @type fun(dv_data: DeltaViewQfListEntryUserData): nil
@@ -98,18 +99,20 @@ local get_deltaview_qf_list_entries = function(deltamenu_items)
     assert(deltamenu_items.ref ~= nil)
     assert(deltamenu_items.mods ~= nil)
     assert(deltamenu_items.changes_data ~= nil)
+    assert(deltamenu_items.git_root ~= nil)
 
     local qflist = {}
     for _, path in ipairs(deltamenu_items.mods) do
         local text = path
         local status = deltamenu_items.changes_data[path].status
         --- @cast status Status
+        local abs_path = utils.git_rel_to_abs(path, deltamenu_items.git_root)
         local filepath
         if status == 'D' then
             -- need /tmp because this isn't a scratch buffer neovim controls the deletion of
-            filepath = '/tmp/deltaview://deleted/' .. utils.git_rel_to_abs(path)
+            filepath = '/tmp/deltaview://deleted/' .. abs_path
         else
-            filepath = utils.git_rel_to_abs(path)
+            filepath = abs_path
         end
         --- @class DeltaViewQfListEntry
         local qflist_entry = {
@@ -119,7 +122,7 @@ local get_deltaview_qf_list_entries = function(deltamenu_items)
             user_data = {
                 deltaview = true,                      -- identifier, allows us to confidently use @cast DeltaViewQfListEntry
                 bufname = path,
-                abs_path = utils.git_rel_to_abs(path), -- note that this is different from filename; is the same most of the time, but for deleted files, can be different
+                abs_path = abs_path, -- note that this is different from filename; is the same most of the time, but for deleted files, can be different
                 show_delta_on_entry = true,
                 ref = deltamenu_items.ref,
                 status = status,
@@ -375,5 +378,6 @@ M.setup_quickfix_deltaview_on_entry()
 --- @field mods string[] list of changed filepaths
 --- @field changes_data ChangesData list of changes data, where the keys are 1 to 1 with mods
 --- @field ref string
+--- @field git_root string
 
 return M

--- a/lua/deltaview/picker.lua
+++ b/lua/deltaview/picker.lua
@@ -120,7 +120,13 @@ M.open_deltaview_fzf_lua_menu = function(deltaview_qf_list, open_dv_func)
 
     -- wipe cached preview buffers on close so they don't leak
     function DeltaviewPreviewer:close(do_not_clear_cache)
+        -- fzf-lua temporarily closes previews when toggling them. Keep the
+        -- active cached buffer detached from the base cleanup in that case.
+        if do_not_clear_cache and is_cached_buf(self.preview_bufnr) then
+            self.preview_bufnr = nil
+        end
         self.super.close(self, do_not_clear_cache)
+        if do_not_clear_cache then return end
         for _, bufnr in pairs(preview_cache) do
             if vim.api.nvim_buf_is_valid(bufnr) then
                 pcall(vim.api.nvim_buf_delete, bufnr, { force = true })

--- a/lua/deltaview/picker.lua
+++ b/lua/deltaview/picker.lua
@@ -51,15 +51,12 @@ M.open_deltaview_fzf_lua_menu = function(deltaview_qf_list, open_dv_func)
 
     local mods, qf_map = get_qf_map(deltaview_qf_list)
 
-    -- Cache of generated diff preview buffers, keyed by entry string (the file's
-    -- bufname). Generating a delta diff spawns several blocking git processes and
-    -- re-runs treesitter highlighting, so we build each file's preview once and
-    -- reuse it on subsequent scrolls. Cleared when the picker closes.
+    -- Diff preview buffers keyed by entry string, reused across scrolls and wiped on close.
     --- @type table<string, number>
     local preview_cache = {}
 
     --- @param bufnr number
-    --- @return boolean true if bufnr is a cached preview buffer we must keep alive
+    --- @return boolean
     local is_cached_buf = function(bufnr)
         for _, cached in pairs(preview_cache) do
             if cached == bufnr then return true end
@@ -83,13 +80,17 @@ M.open_deltaview_fzf_lua_menu = function(deltaview_qf_list, open_dv_func)
         if bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr) then
             vim.api.nvim_win_set_buf(preview_winid, bufnr)
         else
-            local filepath = utils.git_rel_to_abs(entry_str)
-            local ref = qf_map[entry_str].user_data.ref
+            -- reuse precomputed path metadata to avoid a git rev-parse and an
+            -- untracked-file scan on every preview.
+            local user_data = qf_map[entry_str].user_data
+            local filepath = user_data.abs_path
+            local ref = user_data.ref
+            local is_untracked = user_data.is_untracked
             _buf_name_seq = _buf_name_seq + 1
             bufnr = nil
             local success, err = pcall(function()
                 bufnr = view.open_git_diff_buffer_for_path(filepath, ref, state.default_context, preview_winid,
-                    tostring(_buf_name_seq))
+                    tostring(_buf_name_seq), is_untracked)
             end)
             if not success or bufnr == nil then
                 local tmp = self:get_tmp_buffer()
@@ -99,13 +100,14 @@ M.open_deltaview_fzf_lua_menu = function(deltaview_qf_list, open_dv_func)
                 self:set_preview_buf(tmp)
                 return
             end
+            -- delta buffers default to bufhidden=wipe; 'hide' keeps them alive for the cache.
+            vim.bo[bufnr].bufhidden = 'hide'
             preview_cache[entry_str] = bufnr
         end
 
-        -- Inform fzf-lua about the new buffer and clean up the old placeholder.
-        -- Cached buffers stay alive for reuse, so never delete them here.
         self.preview_bufnr = bufnr
         self:set_style_winopts()
+        -- don't delete cached buffers; only placeholders/non-cached ones
         if not is_cached_buf(old_bufnr) then
             self:safe_buf_delete(old_bufnr)
         end
@@ -116,7 +118,7 @@ M.open_deltaview_fzf_lua_menu = function(deltaview_qf_list, open_dv_func)
         self.win:update_preview_title(title)
     end
 
-    -- Wipe cached preview buffers when the picker closes so they don't leak.
+    -- wipe cached preview buffers on close so they don't leak
     function DeltaviewPreviewer:close(do_not_clear_cache)
         self.super.close(self, do_not_clear_cache)
         for _, bufnr in pairs(preview_cache) do
@@ -131,6 +133,10 @@ M.open_deltaview_fzf_lua_menu = function(deltaview_qf_list, open_dv_func)
         prompt = 'DeltaView Menu > ',
         winopts = {
             title = 'comparing to ' .. state.diff_target_ref,
+            -- debounce previews so fast scrolling doesn't render every item passed over
+            preview = {
+                delay = 100,
+            },
         },
         previewer = DeltaviewPreviewer,
         actions = {

--- a/lua/deltaview/picker.lua
+++ b/lua/deltaview/picker.lua
@@ -51,6 +51,22 @@ M.open_deltaview_fzf_lua_menu = function(deltaview_qf_list, open_dv_func)
 
     local mods, qf_map = get_qf_map(deltaview_qf_list)
 
+    -- Cache of generated diff preview buffers, keyed by entry string (the file's
+    -- bufname). Generating a delta diff spawns several blocking git processes and
+    -- re-runs treesitter highlighting, so we build each file's preview once and
+    -- reuse it on subsequent scrolls. Cleared when the picker closes.
+    --- @type table<string, number>
+    local preview_cache = {}
+
+    --- @param bufnr number
+    --- @return boolean true if bufnr is a cached preview buffer we must keep alive
+    local is_cached_buf = function(bufnr)
+        for _, cached in pairs(preview_cache) do
+            if cached == bufnr then return true end
+        end
+        return false
+    end
+
     function DeltaviewPreviewer:new(o, opts, fzf_win)
         self.super.new(self, o, opts, fzf_win)
         setmetatable(self, DeltaviewPreviewer)
@@ -59,33 +75,56 @@ M.open_deltaview_fzf_lua_menu = function(deltaview_qf_list, open_dv_func)
 
     function DeltaviewPreviewer:populate_preview_buf(entry_str)
         if not self.win or not self.win:validate_preview() then return end
-        local filepath = utils.git_rel_to_abs(entry_str)
-        local ref = qf_map[entry_str].user_data.ref
         local preview_winid = self.win.preview_winid
         local old_bufnr = vim.api.nvim_win_get_buf(preview_winid)
-        _buf_name_seq = _buf_name_seq + 1
-        local bufnr = nil
-        local success, err = pcall(function()
-            bufnr = view.open_git_diff_buffer_for_path(filepath, ref, state.default_context, preview_winid,
-                tostring(_buf_name_seq))
-        end)
-        if not success or bufnr == nil then
-            local tmp = self:get_tmp_buffer()
-            vim.api.nvim_buf_set_lines(tmp, 0, -1, false, { 'No diff available for: ' .. entry_str })
-            local lines = vim.fn.split(tostring(err), "\n")
-            vim.api.nvim_buf_set_lines(tmp, 1, -1, false, lines)
-            self:set_preview_buf(tmp)
-            return
+
+        --- @type number | nil
+        local bufnr = preview_cache[entry_str]
+        if bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr) then
+            vim.api.nvim_win_set_buf(preview_winid, bufnr)
+        else
+            local filepath = utils.git_rel_to_abs(entry_str)
+            local ref = qf_map[entry_str].user_data.ref
+            _buf_name_seq = _buf_name_seq + 1
+            bufnr = nil
+            local success, err = pcall(function()
+                bufnr = view.open_git_diff_buffer_for_path(filepath, ref, state.default_context, preview_winid,
+                    tostring(_buf_name_seq))
+            end)
+            if not success or bufnr == nil then
+                local tmp = self:get_tmp_buffer()
+                vim.api.nvim_buf_set_lines(tmp, 0, -1, false, { 'No diff available for: ' .. entry_str })
+                local lines = vim.fn.split(tostring(err), "\n")
+                vim.api.nvim_buf_set_lines(tmp, 1, -1, false, lines)
+                self:set_preview_buf(tmp)
+                return
+            end
+            preview_cache[entry_str] = bufnr
         end
+
         -- Inform fzf-lua about the new buffer and clean up the old placeholder.
+        -- Cached buffers stay alive for reuse, so never delete them here.
         self.preview_bufnr = bufnr
         self:set_style_winopts()
-        self:safe_buf_delete(old_bufnr)
+        if not is_cached_buf(old_bufnr) then
+            self:safe_buf_delete(old_bufnr)
+        end
         local title = ' ' .. qf_map[entry_str].user_data.status
             .. ' ' .. vim.fn.fnamemodify(qf_map[entry_str].user_data.bufname, ':t')
             .. ' > ' .. qf_map[entry_str].user_data.changes .. ' '
 
         self.win:update_preview_title(title)
+    end
+
+    -- Wipe cached preview buffers when the picker closes so they don't leak.
+    function DeltaviewPreviewer:close(do_not_clear_cache)
+        self.super.close(self, do_not_clear_cache)
+        for _, bufnr in pairs(preview_cache) do
+            if vim.api.nvim_buf_is_valid(bufnr) then
+                pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+            end
+        end
+        preview_cache = {}
     end
 
     fzf_lua.fzf_exec(mods, {

--- a/lua/deltaview/utils.lua
+++ b/lua/deltaview/utils.lua
@@ -166,13 +166,14 @@ M.get_sorted_diffed_files = function(ref)
 
     --- @type SortedFile[]
     local sorted_files = {}
-    for file, _ in pairs(files) do
+    for file, tracked in pairs(files) do
         local stats = files_w_stats[file]
         table.insert(sorted_files, {
             name = file,
             added = tonumber(stats.added) or 0,
             removed = tonumber(stats.removed) or 0,
             status = file_statuses[file] or '?',
+            is_untracked = tracked == false,
         })
     end
 
@@ -363,3 +364,4 @@ return M
 --- @field added number
 --- @field removed number
 --- @field status Status
+--- @field is_untracked boolean

--- a/lua/deltaview/utils.lua
+++ b/lua/deltaview/utils.lua
@@ -84,8 +84,9 @@ end
 
 --- gets the number of added lines and deleted lines in the diff, and sorts it
 --- @param ref string target ref
+--- @param git_root string | nil absolute git root, if already known
 --- @return SortedFile[] sorted files
-M.get_sorted_diffed_files = function(ref)
+M.get_sorted_diffed_files = function(ref, git_root)
     assert(ref ~= nil)
     local files = M.get_diffed_and_untracked_files(ref)
     local dirstat_result = vim.system({'git', 'diff', '--no-ext-diff', ref, '-X', '--dirstat=lines,0'}):wait()
@@ -124,9 +125,9 @@ M.get_sorted_diffed_files = function(ref)
 
         if tracked == false then
             -- untracked files have no git history; count all lines as added
-            numstat_result = vim.system({'git', 'diff', '--no-ext-diff', '--numstat', '--no-index', '--', '/dev/null', M.git_rel_to_abs(file)}):wait()
+            numstat_result = vim.system({'git', 'diff', '--no-ext-diff', '--numstat', '--no-index', '--', '/dev/null', M.git_rel_to_abs(file, git_root)}):wait()
         else
-            numstat_result = vim.system({'git', 'diff', '--no-ext-diff', '--numstat', ref, '--', M.git_rel_to_abs(file)}):wait()
+            numstat_result = vim.system({'git', 'diff', '--no-ext-diff', '--numstat', ref, '--', M.git_rel_to_abs(file, git_root)}):wait()
         end
         assert(numstat_result.code == 0 or numstat_result.code == 1)
         -- git diff --numstat outputs "-\t-\t<path>" for binary files; explicitly
@@ -228,11 +229,15 @@ end
 --- git commands like `git diff --name-only` and `git ls-files` output paths
 --- relative to the repository root, not cwd, so this must be used over vim.fn.fnamemodify.
 --- @param rel_path string path relative to the git root
+--- @param git_root string | nil absolute git root, if already known
 --- @return string absolute path
-M.git_rel_to_abs = function(rel_path)
-    local result = vim.system({ 'git', 'rev-parse', '--show-toplevel' }):wait()
-    assert(result.code == 0, 'Failed to get git root. ' .. (result.stderr or ''))
-    return vim.trim(result.stdout) .. '/' .. rel_path
+M.git_rel_to_abs = function(rel_path, git_root)
+    if git_root == nil then
+        local result = vim.system({ 'git', 'rev-parse', '--show-toplevel' }):wait()
+        assert(result.code == 0, 'Failed to get git root. ' .. (result.stderr or ''))
+        git_root = result.stdout
+    end
+    return vim.trim(git_root) .. '/' .. rel_path
 end
 
 

--- a/lua/deltaview/view.lua
+++ b/lua/deltaview/view.lua
@@ -181,15 +181,18 @@ end
 --- @param context number lines of context to show
 --- @param winnr number | nil Optional window number to open on.
 --- @param buf_name string | nil Optional name to assign to the buffer
+--- @param is_untracked boolean | nil Optional untracked status. When provided, skips the git lookup used to determine it.
 --- @return number | nil bufnr buf id of delta.lua buffer
-M.open_git_diff_buffer_for_path = function(path, ref, context, winnr, buf_name)
+M.open_git_diff_buffer_for_path = function(path, ref, context, winnr, buf_name, is_untracked)
     assert(path ~= nil)
     assert(ref ~= nil)
     assert(context ~= nil)
     local ok, delta = pcall(require, 'delta')
     assert(ok, 'Delta.lua module not found. Please verify delta.lua is installed to deltaview.nvim. `:checkhealth deltaview`')
-    local git_root = utils.get_git_root(path)
-    local is_untracked = utils.is_untracked_file(path, git_root)
+    if is_untracked == nil then
+        local git_root = utils.get_git_root(path)
+        is_untracked = utils.is_untracked_file(path, git_root)
+    end
 
     --- @type DeltaOpts
     local opts = { context = context, new_file = is_untracked }

--- a/tests/deltaview/test_menu.lua
+++ b/tests/deltaview/test_menu.lua
@@ -322,6 +322,20 @@ T['create_diff_menu_pane()']['notifies and returns when there are no modified fi
     eq(child.lua_get('_G.fixture.called'), vim.NIL)
 end
 
+T['create_diff_menu_pane()']['forwards git root from initial rev-parse'] = function()
+    child.lua([[
+        _G.fixture.sorted_files = {}
+        _G.fixture.mods = {}
+        package.loaded['deltaview.utils'].get_sorted_diffed_files = function(_ref, git_root)
+            _G.fixture.git_root = git_root
+            return {}
+        end
+        M.create_diff_menu_pane('HEAD')
+    ]])
+
+    eq(child.lua_get('_G.fixture.git_root'), '/repo')
+end
+
 -- choose_deltaview_menu receives an entry with fully-populated user_data for a modified file
 T['create_diff_menu_pane()']['choose_deltaview_menu receives correct entry user_data for a modified file'] = function()
     child.lua([[

--- a/tests/deltaview/test_menu.lua
+++ b/tests/deltaview/test_menu.lua
@@ -325,7 +325,7 @@ end
 -- choose_deltaview_menu receives an entry with fully-populated user_data for a modified file
 T['create_diff_menu_pane()']['choose_deltaview_menu receives correct entry user_data for a modified file'] = function()
     child.lua([[
-        _G.fixture.sorted_files = { { name = 'a.lua', added = 10, removed = 5, status = 'M' } }
+        _G.fixture.sorted_files = { { name = 'a.lua', added = 10, removed = 5, status = 'M', is_untracked = false } }
         _G.fixture.mods = { 'a.lua' }
         _G.fixture.choose_args = nil
         M.choose_deltaview_menu = function(dv_list)
@@ -343,6 +343,7 @@ T['create_diff_menu_pane()']['choose_deltaview_menu receives correct entry user_
     eq(ud.abs_path, '/repo/a.lua')
     eq(ud.ref, 'HEAD')
     eq(ud.status, 'M')
+    eq(ud.is_untracked, false)
     eq(ud.changes, '+10,-5')
     eq(ud.show_delta_on_entry, true)
     eq(args[1].filename, '/repo/a.lua')

--- a/tests/deltaview/test_picker.lua
+++ b/tests/deltaview/test_picker.lua
@@ -299,6 +299,42 @@ T['open_deltaview_fzf_lua_menu()']['winopts title includes diff_target_ref'] = f
     eq(title, 'comparing to HEAD')
 end
 
+T['open_deltaview_fzf_lua_menu()']['preview forwards explicit tracked state when display status is unknown'] = function()
+    child.lua([[
+        local entry = {
+            filename = '/abs/file with spaces.lua',
+            user_data = {
+                deltaview = true,
+                bufname = 'file with spaces.lua',
+                abs_path = '/abs/file with spaces.lua',
+                status = '?',
+                is_untracked = false,
+                changes = '10',
+                ref = 'HEAD',
+            },
+        }
+        package.loaded['deltaview.view'].open_git_diff_buffer_for_path = function(path, _ref, _context, winid, _buf_name, is_untracked)
+            _G.fixture.preview_path = path
+            _G.fixture.preview_is_untracked = is_untracked
+            local bufnr = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_win_set_buf(winid, bufnr)
+            return bufnr
+        end
+        M.open_deltaview_fzf_lua_menu({ entry }, function() end)
+        local previewer = _G.fixture.fzf_opts.previewer
+        previewer.win = {
+            preview_winid = vim.api.nvim_get_current_win(),
+            validate_preview = function() return true end,
+            update_preview_title = function() end,
+        }
+        previewer.set_style_winopts = function() end
+        previewer.safe_buf_delete = function() end
+        previewer:populate_preview_buf('file with spaces.lua')
+    ]])
+    eq(child.lua_get([[_G.fixture.preview_path]]), '/abs/file with spaces.lua')
+    eq(child.lua_get([[_G.fixture.preview_is_untracked]]), false)
+end
+
 T['open_deltaview_fzf_lua_menu()']['default action with nil selected is a no-op'] = function()
     child.lua([[
         _G.fixture.open_dv_called = false

--- a/tests/deltaview/test_picker.lua
+++ b/tests/deltaview/test_picker.lua
@@ -299,6 +299,91 @@ T['open_deltaview_fzf_lua_menu()']['winopts title includes diff_target_ref'] = f
     eq(title, 'comparing to HEAD')
 end
 
+T['open_deltaview_fzf_lua_menu()']['delays previews while scrolling'] = function()
+    child.lua([[M.open_deltaview_fzf_lua_menu(_G.dv_list, function() end)]])
+    eq(child.lua_get([[_G.fixture.fzf_opts.winopts.preview.delay]]), 100)
+end
+
+T['open_deltaview_fzf_lua_menu()']['reuses cached buffers for repeated preview entries'] = function()
+    child.lua([[
+        local render_count = 0
+        package.loaded['deltaview.view'].open_git_diff_buffer_for_path = function(_path, _ref, _context, winid)
+            render_count = render_count + 1
+            local bufnr = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_win_set_buf(winid, bufnr)
+            return bufnr
+        end
+        M.open_deltaview_fzf_lua_menu(_G.dv_list, function() end)
+        local previewer = _G.fixture.fzf_opts.previewer
+        previewer.win = {
+            preview_winid = vim.api.nvim_get_current_win(),
+            validate_preview = function() return true end,
+            update_preview_title = function() end,
+        }
+        previewer.set_style_winopts = function() end
+        previewer.safe_buf_delete = function() end
+        for _, entry in ipairs({ 'a.lua', 'b.lua', 'a.lua', 'b.lua' }) do
+            previewer:populate_preview_buf(entry)
+        end
+        _G.fixture.render_count = render_count
+    ]])
+    eq(child.lua_get([[_G.fixture.render_count]]), 2)
+end
+
+T['open_deltaview_fzf_lua_menu()']['temporary close preserves cached preview buffers'] = function()
+    child.lua([[
+        package.loaded['deltaview.view'].open_git_diff_buffer_for_path = function(_path, _ref, _context, winid)
+            local bufnr = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_win_set_buf(winid, bufnr)
+            _G.fixture.cached_bufnr = bufnr
+            return bufnr
+        end
+        M.open_deltaview_fzf_lua_menu(_G.dv_list, function() end)
+        local previewer = _G.fixture.fzf_opts.previewer
+        previewer.win = {
+            preview_winid = vim.api.nvim_get_current_win(),
+            validate_preview = function() return true end,
+            update_preview_title = function() end,
+        }
+        previewer.set_style_winopts = function() end
+        previewer.safe_buf_delete = function() end
+        previewer.super.close = function(self)
+            if self.preview_bufnr ~= nil then
+                vim.api.nvim_buf_delete(self.preview_bufnr, { force = true })
+            end
+        end
+        previewer:populate_preview_buf('a.lua')
+        previewer:close(true)
+        _G.fixture.cached_buf_is_valid = vim.api.nvim_buf_is_valid(_G.fixture.cached_bufnr)
+    ]])
+    eq(child.lua_get([[_G.fixture.cached_buf_is_valid]]), true)
+end
+
+T['open_deltaview_fzf_lua_menu()']['final close wipes cached preview buffers'] = function()
+    child.lua([[
+        package.loaded['deltaview.view'].open_git_diff_buffer_for_path = function(_path, _ref, _context, winid)
+            local bufnr = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_win_set_buf(winid, bufnr)
+            _G.fixture.cached_bufnr = bufnr
+            return bufnr
+        end
+        M.open_deltaview_fzf_lua_menu(_G.dv_list, function() end)
+        local previewer = _G.fixture.fzf_opts.previewer
+        previewer.win = {
+            preview_winid = vim.api.nvim_get_current_win(),
+            validate_preview = function() return true end,
+            update_preview_title = function() end,
+        }
+        previewer.set_style_winopts = function() end
+        previewer.safe_buf_delete = function() end
+        previewer.super.close = function() end
+        previewer:populate_preview_buf('a.lua')
+        previewer:close(false)
+        _G.fixture.cached_buf_is_valid = vim.api.nvim_buf_is_valid(_G.fixture.cached_bufnr)
+    ]])
+    eq(child.lua_get([[_G.fixture.cached_buf_is_valid]]), false)
+end
+
 T['open_deltaview_fzf_lua_menu()']['preview forwards explicit tracked state when display status is unknown'] = function()
     child.lua([[
         local entry = {

--- a/tests/deltaview/test_utils.lua
+++ b/tests/deltaview/test_utils.lua
@@ -960,6 +960,16 @@ T['git_rel_to_abs()']['throws error when git rev-parse fails'] = function()
     eq(ok, false)
 end
 
+T['git_rel_to_abs()']['uses provided git root without running git rev-parse'] = function()
+    child.lua([[
+        vim.system = function()
+            error('vim.system should not be called when git_root is provided')
+        end
+    ]])
+    local result = child.lua_get([[M.git_rel_to_abs('lua/foo.lua', '/known/repo')]])
+    eq(result, '/known/repo/lua/foo.lua')
+end
+
 -- ──────────────────────────────────────────────────────────────────────────────────────────────
 -- get_filenames_from_sortedfiles() - property based tests
 

--- a/tests/deltaview/test_utils.lua
+++ b/tests/deltaview/test_utils.lua
@@ -813,6 +813,20 @@ T['get_sorted_diffed_files()']['single tracked file returns correct name, added,
     eq(result[1].added,   10)
     eq(result[1].removed, 3)
     eq(result[1].status,  'M')
+    eq(result[1].is_untracked, false)
+end
+
+T['get_sorted_diffed_files()']['tracked filename with spaces is not marked untracked when name-status parsing falls back'] = function()
+    child.lua([[
+        _G.fixture.files_map       = { ['lua/file with spaces.lua'] = true }
+        _G.fixture.dirstat_out     = '  100.0% lua/\n'
+        _G.fixture.name_status_out = 'M\tlua/file with spaces.lua\n'
+        _G.fixture.numstat_map     = { ['/repo/lua/file with spaces.lua'] = '10\t3\tlua/file with spaces.lua\n' }
+    ]])
+    local result = child.lua_get([[M.get_sorted_diffed_files('HEAD')]])
+    eq(#result, 1)
+    eq(result[1].status, '?')
+    eq(result[1].is_untracked, false)
 end
 
 T['get_sorted_diffed_files()']['files sorted by directory dirstat weight descending'] = function()
@@ -883,6 +897,7 @@ T['get_sorted_diffed_files()']['single untracked file returns correct added coun
     eq(result[1].name,    'new_file.lua')
     eq(result[1].added,   7)
     eq(result[1].removed, 0)
+    eq(result[1].is_untracked, true)
 end
 
 T['get_sorted_diffed_files()']['binary untracked file shows 0 added and 0 removed'] = function()


### PR DESCRIPTION
## Summary
- cache fzf-lua `:DeltaMenu` diff preview buffers and reuse them while scrolling
- delay fzf-lua preview rendering briefly so fast scrolling does not render every intermediate entry
- forward precomputed file paths and tracked state into preview rendering to avoid repeated Git lookups
- preserve cached buffers when fzf-lua temporarily hides previews, then clean them up when the picker closes
- document the fzf-lua preview behavior and add focused MiniTest coverage

## Context
Addresses the fzf-lua scrolling portion of #25. The issue can remain open for further large-repository startup improvements.

## Testing
- `make test` (exits `0`; output includes 8 existing integration failures reproduced unchanged on baseline `fed0269`)
- `make test-file FILE=tests/deltaview/test_picker.lua`
- `make test-file FILE=tests/deltaview/test_menu.lua`
- `make test-file FILE=tests/deltaview/test_utils.lua`
- `make test-file FILE=tests/deltaview/test_view.lua`
- `make test-file FILE=tests/deltaview/test_integrations.lua` (same 8 baseline failures)
- `git diff --check fed0269`